### PR TITLE
chore: #13 Claude Code 워크플로우 스킬 4종 추가 (multi-agent-review · plan-issue · raise-pr · manual-test)

### DIFF
--- a/.claude/skills/manual-test/SKILL.md
+++ b/.claude/skills/manual-test/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: manual-test
+description: Playwright MCP로 실제 브라우저를 띄워 이 프로젝트(Next.js + Chakra UI v3)의 UI 플로우를 end-to-end로 시연하고, `USER_JOURNEY.md`의 J1~J17 시나리오 각 상태마다 스크린샷을 남겨 수용 기준과 일치하는지 육안 검증한다. 사용자가 "실제 브라우저로 돌려봐", "UI 직접 확인", "manual test", "J3 시나리오 수동 검증", "브라우저에서 보여줘" 등으로 특정 화면/플로우의 동작 확인을 요청할 때 호출한다. 자동화 테스트(vitest·Playwright e2e)가 통과했더라도 실제 렌더링·스타일·상호작용을 눈으로 확인하고 증적을 남길 때. 원격(배포) URL에 쓰기 작업 시연은 범위 밖 — 읽기만 허용.
+---
+
+# manual-test — Playwright MCP 기반 UI 수동 회귀
+
+이 프로젝트의 UI 플로우를 실제 브라우저로 열어 **시연하고 증적(스크린샷)을 남기는** 워크플로우. `USER_JOURNEY.md`의 J1~J17 시나리오가 기본 실행 카탈로그.
+
+## 언제 쓰는가
+
+- PR 리뷰 전 화면 렌더/레이아웃 육안 확인
+- 자동화 테스트는 통과했지만 CSS·메시지·UX를 직접 확인하고 싶을 때
+- 버그 재현 시나리오를 단계별 스크린샷으로 기록해야 할 때
+- `USER_JOURNEY.md` 하단의 "수동 회귀 체크리스트"를 증적 포함으로 실행할 때
+- 배포 후 공개 URL에서 **읽기 전용** 스모크 확인
+
+**쓰지 말 것**:
+- 회귀 방지용 자동화 — Playwright e2e spec(`tests/e2e/**`)에 고정.
+- 배포된 URL에서 Task 생성/수정/삭제 같은 쓰기 시연 — 공유 상태 오염 위험 → 로컬 환경에서만.
+
+## 전제
+
+- 프로젝트 루트에 `package.json`, `playwright.config.ts` 존재.
+- 현재 세션에서 Playwright MCP 사용 가능 (`mcp__playwright__browser_*`).
+- Node 20+.
+- 시나리오가 DB 상태에 의존하면 Supabase 로컬 컨테이너(`supabase status` ✅) + 로컬 Next.js dev 서버 기동 가능해야 함.
+- `USER_JOURNEY.md`가 최신 상태.
+
+## 워크플로우
+
+### 1. 대상 플로우 확인
+
+사용자 요청에서 다음을 파싱:
+- **시나리오 ID** (예: `J1`, `J3`, `J15`) 또는 경로(`/`, `/tasks` 등)
+- **케이스** (happy / 검증 실패 / 경계값 / 권한 없음 등)
+- **대상 환경**: 로컬(`http://localhost:3000`, 기본) / 배포(`https://<vercel-url>`, 읽기만)
+- **DB 상태 전제**: "빈 상태" / "Given N개 작업 존재" 등 — 필요하면 어떻게 준비할지 확인(아래 3-A 참조)
+
+식별이 애매하면 짧게 질문. 기본은 **로컬 + USER_JOURNEY 해당 시나리오 Given/When/Then 그대로**.
+
+### 2. USER_JOURNEY.md 해당 시나리오 로드
+
+```bash
+grep -A 20 "^### J<N>" USER_JOURNEY.md
+```
+
+Given/When/Then 블록을 뽑아 **실행 체크리스트**로 변환:
+- Given → 준비 단계 (DB 시드, 서버 기동, 브라우저 열기)
+- When → 상호작용 (navigate, fill, click)
+- Then → 검증 (렌더된 문자열/요소/URL/상태)
+
+### 3. 환경 준비
+
+#### 3-A. DB 상태 맞추기 (Given에 전제가 있을 때)
+
+사용자에게 확인:
+> "J<N>의 Given이 `<작업이 N개 존재>`입니다. 현재 로컬 DB 상태 그대로 진행할까요, 아니면 초기화 후 시드할까요?"
+
+- "그대로" → 바로 3-B.
+- "초기화" → 승인 후:
+  ```bash
+  supabase stop && supabase start
+  npm run db:migrate
+  # 시드는 별도 스크립트 또는 UI 조작으로 (supabase db reset 금지 — CLAUDE.md §10)
+  ```
+
+#### 3-B. 개발 서버 기동
+
+`supabase status` + `npm run dev` (백그라운드):
+```bash
+# (필요 시) supabase start
+npm run dev  # run_in_background: true, 출력 파일 확보
+```
+
+`Monitor` 로 ready 신호 대기:
+```
+tail -f <output-file> | grep -E --line-buffered \
+  "Ready in|started server on|error|EADDRINUSE" | head -1
+```
+
+- 성공 시그널: `Ready in XXXms` / `started server on 0.0.0.0:3000`.
+- 실패 시그널: `EADDRINUSE` (포트 이미 사용 중 → `lsof -i :3000` 확인 후 사용자에게 알림) / `Module not found` / `Type error`.
+
+### 4. 브라우저 시연 — 각 시나리오 3단계 증적
+
+Playwright MCP 툴 사용 패턴:
+
+1. **초기 상태 (Given)**
+   - `browser_navigate` → `http://localhost:3000<path>`
+   - `browser_snapshot` → 접근성 트리 확인 (엘리먼트 `ref=eN` 확보; fill/click에 필수)
+   - Chakra v3 + next-themes 테마 flash 대기: `browser_wait_for` 로 `networkidle` 또는 특정 텍스트/요소 등장까지.
+   - `browser_take_screenshot` → `<scenario-id>-<state>.png` 예: `j1-empty-state.png`
+
+2. **입력/상호작용 (When)**
+   - `browser_fill_form` (여러 필드 일괄) 또는 `browser_type` (단일 필드)
+   - 필요 시 `browser_take_screenshot` → `<scenario>-filled.png`
+   - `browser_click` 로 submit/action
+
+3. **결과 (Then)**
+   - 페이지 전환 시 새 snapshot이 tool result에 포함됨
+   - 검증: 기대 문자열/요소/URL 확인
+   - `browser_take_screenshot` → `<scenario>-<result>.png` 예: `j3-after-add.png`, `j15-overdue-stripe.png`
+
+시나리오를 연달아 돌릴 때는 사이에 `browser_navigate`로 초기 URL 재진입 (폼/상태 리셋) 또는 DB 상태 재준비.
+
+### 5. 정리
+
+- `mcp__playwright__browser_close` — 페이지 닫기
+- `TaskStop` — `npm run dev` 백그라운드 태스크 중단 (사용자가 "켜둬"라고 하지 않은 한)
+- `Monitor`도 정리
+
+### 6. 결과 보고 (표 형태)
+
+| 시나리오 | 상태 | 스크린샷 | 메모 |
+|---|---|---|---|
+| J1 빈 상태 | ✅ | `j1-empty-state.png` | 안내 문구 "아직 작업이 없습니다" 확인, `+ 작업 추가` 버튼 렌더 |
+| J3 작업 생성 | ✅ | `j3-filled.png`, `j3-after-add.png` | 모달 입력 → 목록 최상단 추가 |
+| J15 Overdue 빗금 | ❌ | `j15-expected-stripe.png` | 빗금이 렌더되지 않음. SPEC §5.3에 정의된 시각 표시 누락 → 이슈 #11로 보고 |
+
+자동 테스트가 검증하는 계약과 실제 렌더링이 일치하는지 명시. **불일치 발견 시 즉시 보고** — 테스트 계약과 UI 문구 중 어느 쪽을 맞출지 사용자에게 결정 요청.
+
+## 가이드라인
+
+- **시나리오 ID 일관성**: 스크린샷 파일명은 반드시 `<scenario-id>-<state>.png` 형태. 보고서 표에서도 ID로 지칭(`J15 통과`, `J3 실패`).
+- **엘리먼트 참조는 snapshot에서만**: `browser_snapshot` 반환한 `ref=eN` 값을 `fill_form`/`click`의 `ref`에 그대로 전달. CSS selector 추측 금지.
+- **Chakra v3 렌더 타이밍**: `next-themes`와 연동되어 **hydration 이후 색상/테마가 바뀔 수 있음**. 스크린샷 전 `browser_wait_for` 로 네트워크 idle + 특정 요소 등장 대기.
+- **DB 상태 오염 주의**: J2~J8 같은 CRUD 시나리오 후에는 다음 시나리오 전에 DB를 되돌릴지 그대로 둘지 사용자 확인. `supabase db reset` 금지 (CLAUDE.md §10) — 필요하면 `supabase stop/start + db:migrate + 재시드`.
+- **원격(배포) 환경**: `NEXT_PUBLIC_SUPABASE_URL`이 `.supabase.co` 도메인인 환경에서는 **읽기만** 허용. 생성/수정/삭제 조작은 로컬에서만 시연.
+- **기동 시간 대응**: 첫 `next dev` 컴파일은 2~5초. `Monitor` 시그널 대기 후 navigate. `sleep` 조합 금지.
+- **한 시나리오는 한 턴에 몰아서**: navigate → snapshot → fill → click → screenshot. 중간 설명 최소화.
+- **한국어**로 대화.
+
+## 자주 쓰는 경로 (이 프로젝트 기준)
+
+- `/` — 홈 (Task 목록 + 간트 뷰, SPEC §5)
+- `/` 빈 상태 → J1
+- `+ 작업 추가` 모달 → J2, J3
+- 인라인 편집 → J4~J7
+- CSV Import/Export → J10, J11
+- 간트 뷰 → J12~J15
+
+UI 없는 Route Handler(`app/api/**`) 검증은 이 스킬 범위 밖 — `curl` / `fetch` 통합 테스트로.
+
+## 후속 제안
+
+시연 중 자동화하면 좋은 케이스를 발견하면:
+- **Vitest unit/integration 추가** (`tests/unit/**`, `tests/integration/**`) — 빠르고 CI 기본 포함.
+- **Playwright e2e 추가** (`tests/e2e/**`) — USER_JOURNEY 시나리오를 `describe('J<N> — 제목', …)` 로 묶어 고정.
+
+자동화 제안은 이 스킬에서 수행하지 말고 사용자에게 "이 시나리오는 Playwright e2e로 고정할까요?"로 넘기라.
+
+## 범위 밖
+
+- 회귀 방지 자동화 spec 작성 — `tests/e2e/**`에 직접 추가 (`plan-issue` → `raise-pr` 흐름으로).
+- 배포 URL에서 쓰기 작업 시연.
+- 브라우저 확장/플러그인이 필요한 시나리오 (예: 실제 Supabase 대시보드 조작).
+- 시각 회귀(스크린샷 diff) 툴링 세팅.
+
+## 실행 예시 — J1 + J3 수동 회귀
+
+**사용자**: "J1이랑 J3 브라우저로 확인해줘. 현재 DB 상태는 비어 있다고 가정."
+
+**Claude**:
+1. `grep -A 20 "^### J1" USER_JOURNEY.md` + `J3` 동일.
+2. `supabase status` 확인 → ✅. `npm run dev` 백그라운드 기동 + Monitor `Ready in` 대기.
+3. J1:
+   - `browser_navigate http://localhost:3000` → `browser_snapshot` → `browser_wait_for("아직 작업이 없습니다")` → `j1-empty-state.png`
+4. J3:
+   - `browser_click ref=<+ 작업 추가>` → `browser_snapshot` (모달)
+   - `browser_fill_form({title:"첫 번째 작업", startDate:"2026-04-25", dueDate:"2026-04-30"})` → `j3-filled.png`
+   - `browser_click ref=<저장>` → `browser_wait_for("첫 번째 작업")` → `j3-after-add.png`
+5. `browser_close` + `TaskStop npm run dev`.
+6. 결과 표 + "J3 after 상태에서 목록 최상단에 바로 뜨는 것 확인. 간트 뷰의 막대는 다음 단계(J12)에서 확인 가능" 메모.

--- a/.claude/skills/multi-agent-review/SKILL.md
+++ b/.claude/skills/multi-agent-review/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: multi-agent-review
+description: 하나의 PR/브랜치에 대해 `code-reviewer`(품질·아키텍처) / `security-reviewer`(보안·시크릿) / `test-engineer`(테스트·CI) 세 OMC 서브에이전트를 병렬 실행하고, 세 리포트를 교차 검증해 (1) 공통으로 지목된 진짜 리스크, (2) 관점별 고유 결함, (3) P0~P2 우선순위 개선안으로 정리해 돌려준다. 사용자가 "멀티 에이전트 리뷰", "multi agent review", "세 관점으로 리뷰", "크로스체크 리뷰", "리뷰어 여러 명 돌려줘", "PR 병렬 리뷰" 등으로 요청할 때 호출한다. 단일 관점 리뷰는 범위 밖 — 해당 에이전트를 직접 호출하면 된다. 이슈 생성·코드 수정도 범위 밖(`plan-issue`, `raise-pr` 담당).
+---
+
+# multi-agent-review — 세 관점 병렬 리뷰 + 교차 검증
+
+하나의 PR을 **품질·아키텍처 / 보안 / 테스트·CI** 세 리뷰어가 각각 독립적으로 읽고, 메인 프로세서가 세 리포트를 병합해 **진짜 블로커**와 **관점별 고유 결함**을 분리해 제시한다.
+
+## 왜 이 스킬이 필요한가
+
+메인 프로세스는 자기가 짠 코드를 "괜찮다"고 판단하는 편향이 있다. 코드와 무관한 별도 서브에이전트에게 관점을 나눠 맡기면:
+
+- **단일 관점 리뷰가 놓치는 교집합 리스크가 드러난다** — 세 관점이 동시에 같은 결함을 지목하면 토론의 여지 없는 머지 블로커.
+- **관점별 격리로 중복 노이즈가 없다** — 한 에이전트가 모든 관점을 섞어 보는 것보다 각 관점의 깊이가 더 깊음.
+- **메인 프로세서 컨텍스트 절약** — 세 리포트 원문은 종합 보고 형태로만 소비되므로 후속 작업 여유가 남음.
+
+## 언제 쓰는가
+
+- PR 머지 전 한 컨텍스트에서 품질·보안·테스트를 모두 검토.
+- 리뷰 결과로 후속 이슈를 쪼갤 근거가 필요할 때.
+- 자동화 테스트가 통과했지만 "이 PR이 진짜 준비됐는가"를 독립 관점으로 확인하고 싶을 때.
+
+**쓰지 말 것**:
+- 한 관점만 필요 → 해당 에이전트(`code-reviewer`/`security-reviewer`/`test-engineer`)를 직접 호출.
+- 1~2파일짜리 자명한 수정 → 오버킬.
+- 아직 코드가 다 안 된 상태 → 먼저 구현을 마치고 호출.
+
+## 전제
+
+- 저장소 루트에 `CLAUDE.md`·`SPEC.md`·`USER_JOURNEY.md` 존재 (세 리뷰어가 공통 근거로 삼음).
+- `gh` CLI 인증 완료.
+- PR 번호 **또는** 로컬 브랜치가 사용자 프롬프트 또는 현재 상태에서 식별 가능.
+- OMC 에이전트(`oh-my-claudecode:code-reviewer` / `oh-my-claudecode:security-reviewer` / `oh-my-claudecode:test-engineer`)가 가용 상태.
+
+## 워크플로우
+
+### 1. 대상 확정
+
+사용자 프롬프트에서 PR 번호(`#12`, `PR 12`)를 파싱. 없으면:
+
+```bash
+gh pr view --json number,headRefName,title
+```
+
+현재 브랜치의 PR을 조회. PR이 없고 브랜치만 있다면 브랜치 diff(`git diff main...<branch>`)만으로 진행. PR 번호를 못 찾으면 **사용자에게 확인** 후 진행.
+
+diff·PR 본문·파일 리스트를 먼저 한 번 읽어 **공통 Context 문단**(1~2문장)을 작성한다. 예:
+> "이슈 #1 부트스트랩 PR. Next.js 14 + Chakra UI v3 + Supabase @supabase/ssr + Drizzle postgres-js 클라이언트를 import 가능한 상태까지 올리는 PR로, tasks 테이블 정의는 #2 범위."
+
+### 2. 세 에이전트 병렬 실행 — **한 메시지에서 세 Agent 호출**
+
+병렬이 이 스킬의 핵심이다. 반드시 **같은 응답 안에 세 개의 Agent tool call**을 넣는다. 순차 호출 금지.
+
+각 호출 공통:
+
+- `subagent_type`: OMC 에이전트 이름
+- `prompt`: 아래 템플릿 — 공통 Context + 관점별 스코프 + 공통 출력 포맷
+- **세 프롬프트의 `Context`는 동일**. 세 리뷰어가 서로의 결과를 모른 채 독립 판단하도록 한다 (메인 프로세서의 결론·한쪽 리뷰어의 결론을 다른 리뷰어 프롬프트에 섞지 마라 — 편향 유발).
+
+#### 프롬프트 템플릿 (스코프만 교체)
+
+```
+GitHub PR #<N> (`<head-ref>` → `<base-ref>`)에 대해 **<관점 한국어 이름>** 관점으로 리뷰해 주세요.
+저장소: `<absolute repo path>`. 프로젝트: 교육용 WBS (Next.js 14 App Router + Chakra UI v3 + Supabase @supabase/ssr + Drizzle postgres-js).
+
+## 공통 Context
+<1~2문장 — 이 PR이 다루는 slice, 이전/다음 이슈 맥락>
+
+## 리뷰 스코프 (이 관점에만 집중 — 다른 관점은 건드리지 마세요)
+<관점별 bullet 5~10개>
+
+## 근거 문서
+- CLAUDE.md §2(스택), §3(스키마), §6(워크플로우), §9(커밋), §10(금기)
+- SPEC.md §9(범위 밖)
+- USER_JOURNEY.md (J1~J17 시나리오)
+
+## 리뷰 방법
+1. `gh pr diff <N> --patch` 로 패치 읽기 + 파일별 Read 병행.
+2. 각 지적에 severity 라벨 + 파일:라인 + 구체적 개선안 포함.
+3. **다른 관점은 언급만, 제안은 원주인 스코프에 위임**.
+
+## 출력 형식 (markdown, 한국어, 요약 600자 이내)
+<관점별 섹션 템플릿>
+
+파일 수정하지 말고 리뷰 결과만 돌려주세요.
+```
+
+#### 관점별 스코프
+
+**A. 품질·아키텍처 — `oh-my-claudecode:code-reviewer`**
+- 아키텍처 선택 (Next.js 풀스택 전제, Server/Client 경계, 별도 백엔드 금지), 레이어 분리(`app/` · `components/` · `lib/supabase/` · `lib/db/` · `drizzle/`)
+- TypeScript strict, 네이밍, 파일 구조, Chakra UI v3 API 정합
+- `drizzle.config.ts` §6 규약(`schema`, `out`, `strict`, `verbose`) 일치
+- `package.json` 스크립트 이름(`db:generate`/`db:migrate`/`db:studio`/`test`/`test:e2e`) 및 버전 정합
+- SOLID/DRY/KISS, CLAUDE.md §10 금기(Tailwind·shadcn 혼용, `drizzle-kit push`, `supabase db reset` 등) 위반
+- severity: Blocker / Major / Minor / Nit
+- 섹션: `## 요약` → `## Blocker` → `## Major` → `## Minor` → `## Nit` → `## 긍정 포인트`
+
+**B. 보안 — `oh-my-claudecode:security-reviewer`**
+- 환경변수: `NEXT_PUBLIC_*` 접두사 규칙, service role key 클라이언트 번들 유출, `.env.local` 계열 `.gitignore` 포함
+- `lib/supabase/client.ts` (브라우저) vs `server.ts` (서버) 경계, `server-only` 가드 유무
+- `DATABASE_URL` 분리: 마이그레이션(5432 Direct/Session pooler) vs 런타임(6543 Transaction pooler), Transaction pooler로 migrate 돌릴 위험
+- `.github/workflows/` secret 취급, 이벤트 트리거 범위, 액션 버전 핀(SHA vs `@v4`), `permissions:` 최소화
+- `package-lock.json` 상위 deps 취약성 스캔(특히 Next.js CVE)
+- RLS 전제(MVP off) × 이 PR의 상호작용
+- OWASP(A01 access control, A02 crypto failures, A05 misconfig, A07 auth, A08 integrity)
+- severity: Critical / High / Medium / Low / Info
+- 섹션: `## 요약` → `## Critical` → `## High` → `## Medium` → `## Low` → `## Info` → `## Security Checklist`
+
+**C. 테스트·CI — `oh-my-claudecode:test-engineer`**
+- 테스트가 의미 있는 보장을 제공하는지(문자열 존재 검증 vs 실제 계약 검증)
+- `USER_JOURNEY.md` J1~J17 시나리오 매핑(테스트 `describe` 블록에 시나리오 ID 포함되는지)
+- Vitest 구성(`vitest.config.ts`, `vitest.setup.ts` — jsdom, RTL, cleanup, matcher 로딩)
+- Playwright 구성(`playwright.config.ts` — webServer/baseURL/trace/retries/reuseExistingServer/timeout)
+- `.github/workflows/ci.yml` 잡 구성(Node 20, caching, playwright install, artifact, fail-fast, 병렬성, concurrency)
+- TDD 흐름(RED 커밋이 진짜 RED였는지, 현재 GREEN 유지되는지 — 필요시 `npm test` 실제 실행)
+- Flaky 리스크(dev 서버 cold start 타이밍, 병렬 DB 충돌 가능성)
+- Page Object / fixture / DB seed 전략 부재 여부
+- severity: Blocker / Major / Minor / Nit
+- 섹션: `## 요약` → `## 커버리지 갭` → `## Flakiness 리스크` → `## CI 구성 개선` → `## 향후 TDD 확장 준비도` → `## 긍정 포인트`
+
+### 3. 교차 검증 (cross-check)
+
+세 리포트가 돌아오면 메인 프로세서가 직접 교차표를 작성한다. 메모리·파일이 아니라 **응답 안에** 그려서 사용자에게 보여준다.
+
+| # | 이슈 요약 | 품질 | 보안 | 테스트 |
+|---|-----------|:----:|:----:|:------:|
+| C1 | ... | ✔ | ✔ | ✔ |
+| C2 | ... | ✔ | ✔ | — |
+
+- **둘 이상에서 지목 = 진짜 리스크 (P0 후보)**
+- 한 관점 단독 = 그 관점의 고유 관찰 (P1/P2 후보)
+- 표기는 "공통 이슈" 블록(`C1`, `C2`, …)으로 먼저 묶고, 이어서 "관점별 고유 이슈"로 내려간다.
+
+### 4. 우선순위별 개선안으로 정리
+
+사용자에게 반환할 최종 포맷:
+
+```markdown
+# PR #<N> 종합 리뷰 — `<branch>`
+
+## 전체 평가
+<2~4줄: 머지 가능 여부, 세 리뷰어의 공통 기저 판단, 구조적 약점 한 문장>
+
+## 🔴 세 관점이 동시에 지적한 공통 이슈 (최우선)
+### C1. <제목>
+- 품질: ...
+- 보안: ...
+- 테스트: ...
+- **개선안**: ...
+
+### C2. ...
+
+## 🟡 관점별 고유 이슈
+### 품질/아키텍처
+- **[Major] 파일:라인** — 문제. 개선안.
+- ...
+
+### 보안
+- **[High] 파일:라인** — 문제. 영향. 개선안.
+- ...
+
+### 테스트/CI
+- **[Major] 파일:라인** — 문제. 개선안.
+- ...
+
+## 🟢 세 리뷰어 모두 칭찬한 부분
+- ...
+
+## 추천 처리 순서
+| 우선순위 | 작업 | 근거 |
+|---|---|---|
+| P0 (이 PR에 추가 커밋) | ... | ... |
+| P1 (이 PR 또는 후속 커밋) | ... | ... |
+| P2 (별도 이슈) | ... | ... |
+| P3 (메모) | ... | ... |
+```
+
+**CLAUDE.md §9 "한 커밋 = 한 논리 단위" 원칙을 우선순위표에 의식적으로 반영**한다. P0 묶음이 한 커밋에 담기지 않는 규모면 하위 분할안까지 본문에 포함.
+
+### 5. 종료
+
+- 세 리뷰어의 원문 리포트는 **요청이 있을 때만** 전체 공개. 기본은 종합 리뷰만 출력.
+- 이슈 생성·코드 수정·PR 코멘트 작성은 **별도 턴** 또는 다른 스킬(`raise-pr`, `plan-issue`) 담당.
+
+## 가이드라인
+
+- **세 Agent 호출은 반드시 한 메시지 = 진짜 병렬.** 순차 호출은 시간·토큰 낭비이고 어차피 독립 판단이 목적이므로 순서 의미 없음.
+- **스코프 침범 감시**: 같은 결함이 두 리포트에 동시에 등장하면 **원주인 스코프로 귀속**하고 다른 쪽에서는 언급만 (교차표의 가치가 오히려 커진다).
+- **중립적 Context 전달**: 메인 프로세서의 선입견을 프롬프트에 섞지 마라 ("시크릿 관리가 허술해 보이는데 확인" 금지 — 리뷰어가 그 지점만 보게 된다).
+- **CLAUDE.md §9 기반 권고**: 개선안은 커밋 분리를 전제로 묶어라.
+- **사용자가 "원문 보고서"를 요구하면** 세 리포트를 순서대로(품질 → 보안 → 테스트) 그대로 덤프.
+- 한국어로 대화.
+
+## 범위 밖
+
+- 이슈 생성 — `plan-issue` 스킬 또는 별도 턴.
+- 코드 수정 · 테스트 실행 · PR 코멘트 자동 작성 — 이 스킬은 **리뷰 결과물만** 책임.
+- 단일 관점 리뷰 — 해당 에이전트 직접 호출.
+- 비-PR 전체 감사(아키텍처 deep-dive, security audit 전반) — 다른 스킬 또는 general-purpose.
+
+## 예시 실행 — PR #12
+
+**사용자**: "PR #12 멀티 에이전트 리뷰 돌려줘."
+
+**메인 프로세서**:
+1. `gh pr view 12 --json headRefName,title,body` → branch=`feat/issue-1-bootstrap`, title=`feat: #1 bootstrap …`
+2. `gh pr diff 12 --name-only` + 본문에서 공통 Context 도출.
+3. **한 메시지에서 세 Agent tool call 동시 호출**:
+   - `subagent_type=oh-my-claudecode:code-reviewer`, scope=품질·아키텍처
+   - `subagent_type=oh-my-claudecode:security-reviewer`, scope=보안
+   - `subagent_type=oh-my-claudecode:test-engineer`, scope=테스트·CI
+4. 세 리포트 수신 → 공통/고유 finding 교차표 작성 → P0~P3 개선안 표 작성.
+5. 사용자에게 종합 리포트만 제시. 원문은 요청 시 공개.

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: plan-issue
+description: GitHub 이슈 번호를 받아 `SPEC.md` · `USER_JOURNEY.md` · `CLAUDE.md` 규약을 근거로 TDD 슬라이스(RED → GREEN → REFACTOR) 단위로 쪼갠 구현 계획을 세운다. 사용자가 "이슈 #3 계획 세워줘", "plan issue 5", "이슈부터 분석해줘", "구현 계획 짜줘" 등으로 요청할 때 호출한다. 입력은 이슈 번호(또는 URL). 구현·커밋·PR 생성은 **범위 밖** — 오직 계획서만 돌려준다. 스펙에 없는 기능을 요청하면 먼저 `SPEC.md` 갱신을 제안하고 중단한다.
+---
+
+# plan-issue — 이슈 번호 → TDD 구현 계획
+
+GitHub 이슈 하나를 받아 "이 이슈를 어떻게 쪼개 구현할 것인가"를 **TDD 커밋 단위 + 파일 리스트 + 시나리오 매핑**으로 정리해 돌려주는 스킬. 이 스킬은 **계획만** 한다. 실제 파일을 수정하거나 커밋하지 않는다.
+
+## 왜 이 스킬이 필요한가
+
+- CLAUDE.md §1은 "한 번의 응답에 너무 많은 파일을 동시에 생성·수정하지 않는다. GitHub Issue 하나 = 커밋 하나"를 요구한다.
+- §1-B는 "기능 구현 요청이 들어오면 먼저 `SPEC.md`를 읽고, 충돌·누락 시 먼저 스펙을 고친다"를 요구한다.
+- §6은 스키마 변경 시 `schema.ts → generate → 리뷰 → migrate → 커밋` 순서를 강제한다.
+- 수강생은 "이슈를 어떻게 쪼개야 하는지" 감이 없다. 매번 이걸 직접 설명하지 말고, 규약 기반 자동 계획으로 일관되게 제시한다.
+
+## 언제 쓰는가
+
+- `/plan-issue 3` 처럼 이슈 번호를 전달하며 "이 이슈부터 시작해줘"라고 할 때.
+- 큰 이슈(여러 체크박스 포함)를 시작하기 전에 커밋 슬라이스를 미리 합의하고 싶을 때.
+- `SPEC.md`에 없는 기능인지 먼저 확인받고 싶을 때.
+
+**쓰지 말 것**:
+- 계획 없이 바로 구현하고 싶을 때 — 자유 대화로 진행.
+- 이미 계획이 있고 구현만 남은 경우 — 바로 구현 또는 `raise-pr`.
+- PR 단위 리뷰 — `multi-agent-review`.
+
+## 전제
+
+- 저장소 루트에 `SPEC.md`, `USER_JOURNEY.md`, `CLAUDE.md` 존재.
+- `gh` CLI 인증 완료.
+- 대상 이슈가 이미 GitHub에 존재 (`gh issue list`).
+
+## 워크플로우
+
+### 1. 입력 파싱 및 이슈 읽기
+
+```bash
+gh issue view <N> --json number,title,body,labels,state
+```
+
+`state: "OPEN"`이 아니면 "이미 닫힌 이슈인데 계속 진행할까요?" 질문. 본문의 체크박스 `- [ ]` 를 **항목 리스트로 추출**.
+
+이슈 번호를 못 받았으면:
+```bash
+gh issue list --state open --json number,title --limit 20
+```
+보여주고 "어느 이슈인가요?" 질문.
+
+### 2. `SPEC.md` · `USER_JOURNEY.md` 교차 확인
+
+1. `SPEC.md` 전문을 읽는다.
+2. 이슈가 다루는 기능을 `SPEC.md`의 섹션(1~8)과 매핑.
+3. 다음 3 케이스로 분기:
+
+| 케이스 | 대응 |
+|---|---|
+| **스펙에 이미 정의됨** | 정의 그대로 따르기. 계획서에 해당 SPEC 섹션 ID 인용. |
+| **스펙과 충돌** | 계획 수립을 멈추고 사용자에게 "SPEC을 업데이트할까요, 기존 정의를 따를까요?" 확인. |
+| **스펙에 없음** | 계획 수립을 멈추고 "SPEC.md에 먼저 항목을 추가할까요?" 확인. 승인되면 SPEC 편집안을 먼저 제안. |
+
+4. `USER_JOURNEY.md`에서 이 이슈에 **대응하는 시나리오 ID(J1~J17)**를 찾는다. 없으면 "USER_JOURNEY에 시나리오를 먼저 추가할까요?"로 확인.
+
+### 3. 스키마 변경 여부 판단
+
+이슈가 `lib/db/schema.ts`를 건드릴 가능성이 있으면(`[db]` 라벨, tasks 테이블 언급, 필드 추가/삭제 등), CLAUDE.md §6의 스키마 변경 순서를 계획에 박는다:
+
+1. `lib/db/schema.ts` 수정
+2. `npm run db:generate` → `drizzle/` 폴더에 SQL 생성
+3. 생성된 SQL 리뷰 (의도 확인)
+4. `npm run db:migrate` → 로컬 DB 적용
+5. 타입 오류 수정 + 기능 검증
+6. `lib/db/schema.ts` + `drizzle/*.sql` + `drizzle/meta/*` 를 **한 커밋**으로 푸시
+
+스키마 변경이 없으면 이 섹션은 건너뛴다.
+
+### 4. TDD 슬라이스로 쪼개기
+
+이슈 전체를 **3~6개의 커밋 슬라이스**로 나눈다. CLAUDE.md §9 "한 커밋 = 한 논리 단위" + Conventional Commits 규약. 각 슬라이스는 다음 중 하나:
+
+- `test: #<N> <RED 설명>` — 실패하는 테스트 추가(이 이슈의 계약을 정의)
+- `feat: #<N> <GREEN 설명>` — 테스트를 통과시키는 최소 구현
+- `refactor: #<N> <REFACTOR 설명>` — 정리, 네이밍, 중복 제거 (필요 시)
+- `chore: #<N> <…>` — 설정/의존성
+- `fix: #<N> <…>` — 버그 수정
+- `docs: #<N> <…>` — SPEC/USER_JOURNEY/CLAUDE 갱신
+
+각 슬라이스에 다음을 명시:
+- 건드릴 **파일 경로 리스트** (절대 경로 or 저장소 상대 경로)
+- 관련 **USER_JOURNEY 시나리오 ID** (J1, J2, …)
+- 예상 **테스트 파일** (`tests/unit/…`, `tests/integration/…`, `tests/e2e/…`)
+- **검증 명령** (`npm run lint` / `npm test` / `npm run build` / `npm run test:e2e`)
+- 스키마 변경이면 **drizzle 순서** 재인용
+
+### 5. 계획서 출력 포맷
+
+```markdown
+# 이슈 #<N> 구현 계획 — <title>
+
+## 스펙 근거
+- SPEC.md §<섹션> — <인용 또는 요약>
+- USER_JOURNEY.md — **J<x>**, **J<y>** (… 한 줄 요약)
+
+## 전체 스코프
+<2~4줄: 이 이슈가 끝났을 때 수강생이 할 수 있게 되는 것. SPEC에서 그대로 인용.>
+
+## 범위 밖 (의식적으로 안 하는 것)
+- <다른 이슈로 빠지는 항목>
+- <SPEC §9 "범위 밖"에 들어가는 항목>
+
+## 커밋 슬라이스
+
+### 1. `test: #<N> <RED>` — 실패하는 테스트
+**파일**:
+- `tests/unit/<…>.test.ts` (새 파일)
+
+**시나리오**: J<x> Given/When/Then
+**검증**: `npm test` → 이 테스트만 실패해야 함 (다른 테스트는 그대로 통과)
+**예상 실패 메시지**: "…"
+
+### 2. `feat: #<N> <GREEN>` — 테스트 통과
+**파일**:
+- `lib/db/schema.ts` (수정, 스키마 변경 시)
+- `drizzle/<timestamp>_<name>.sql` (자동 생성, 커밋 대상)
+- `drizzle/meta/*` (자동 생성, 커밋 대상)
+- `app/page.tsx` (수정)
+- `components/<…>.tsx` (새 파일)
+
+**스키마 변경 순서** (해당 시):
+1. `lib/db/schema.ts` 수정
+2. `npm run db:generate`
+3. 생성된 SQL 리뷰
+4. `npm run db:migrate`
+5. 앱 코드 수정 + 타입 오류 해결
+6. 위 파일 모두 한 커밋
+
+**시나리오**: J<x>, J<y>
+**검증**: `npm test` + `npm run lint` + `npm run build` (필요 시 `npm run test:e2e`)
+
+### 3. `refactor: #<N> <…>` — (필요 시)
+...
+
+## 선행 조건
+- [ ] 이슈 #<M> 완료 (<이유>)
+- [ ] `supabase status` 가 ✅ — 로컬 DB 기동 중
+- [ ] `.env.local` 에 `DATABASE_URL`·`NEXT_PUBLIC_SUPABASE_*` 세팅됨
+
+## 이후 워크플로우
+이 계획 승인 후 구현이 끝나면 **`/raise-pr`** 로 PR 생성 → CI 통과 후 **`/multi-agent-review <PR번호>`** 로 세 관점 리뷰 받는 순서 권장.
+
+## 주의 (있을 때만)
+- CLAUDE.md §10 금기사항 중 이 이슈에서 실수하기 쉬운 항목 환기
+- SPEC.md §9 "범위 밖"에 닿는 유혹 지점
+```
+
+### 6. 승인 요청
+
+계획서 출력 후 사용자에게 다음 중 하나로 질문:
+
+> 이대로 구현을 시작할까요? 수정이 필요하면 말씀해주세요. (예/수정 요청)
+
+- "예" → 이 스킬은 종료. 메인 세션에서 첫 번째 슬라이스(보통 RED 테스트)부터 구현에 들어감.
+- 수정 요청 → 계획서를 고쳐 다시 보여줌.
+
+## 가이드라인
+
+- **SPEC이 정답**. 이슈 본문이 SPEC과 다르면 SPEC을 믿고 이슈를 고치는 쪽으로 유도.
+- **한 커밋 = 한 논리 단위 = ≤ 수강생이 이해할 수 있는 크기**. 한 슬라이스가 10+ 파일을 건드리게 잡히면 더 쪼개라.
+- **드리즐 변경은 반드시 한 커밋**. `schema.ts`만 커밋하고 `drizzle/` 폴더를 뺀 상태의 PR은 절대 제안하지 않는다.
+- **테스트 먼저**. RED 커밋이 없는 슬라이스를 제안하지 마라 (정말 테스트 불가능한 경우 — UI 폴리시, 순수 설정 — 에만 예외 허용).
+- **USER_JOURNEY 매핑 필수**. 시나리오 ID가 없는 기능 슬라이스는 `USER_JOURNEY.md`부터 먼저 고치라고 안내.
+- **추정 금지**. 이슈 본문에 없는 요구를 계획에 섞지 마라 — SPEC에 추가한 다음 이슈 본문도 업데이트한 뒤 계획에 포함.
+- **파일을 수정하거나 커밋하지 않는다**. 이 스킬은 오직 markdown 출력만.
+- 한국어로 대화.
+
+## 범위 밖
+
+- 실제 파일 생성·수정 — 메인 세션에서 계획 승인 후 진행.
+- `git commit` / `gh pr create` — `raise-pr` 스킬.
+- 리뷰 — `multi-agent-review` 스킬.
+- 수동 브라우저 확인 — `manual-test` 스킬.
+- `SPEC.md` · `USER_JOURNEY.md` 편집 — 승인 후 **별도 턴**에서 먼저 진행하고 돌아와 계획 재수립.
+
+## 예시 실행 — 이슈 #2
+
+**사용자**: "/plan-issue 2"
+
+**Claude**:
+1. `gh issue view 2` → `[db] lib/db/schema.ts에 tasks 테이블 정의 + drizzle-kit generate/migrate로 로컬 적용`
+2. `SPEC.md` §3 읽음 → tasks 데이터 모델 정의 확인. CLAUDE.md §3에도 Drizzle DSL 원본이 박혀 있음 — 정합.
+3. `USER_JOURNEY.md` 검토 → 이 이슈는 인프라라 시나리오 직접 매핑 없음. 다만 이후 J1(빈 상태), J2(첫 작업 추가)가 이 스키마 위에서 돌아감.
+4. 스키마 변경 **있음** → §6 순서 반영.
+5. 커밋 슬라이스:
+   - `test: #2 tasks schema contract test (RED)` — `tests/contract/tasks-schema.test.ts` 에서 `tasks` 테이블 존재 + status/progress check constraint 검증 (DB 쿼리 or drizzle 메타 리플렉션)
+   - `feat: #2 define tasks table + initial migration (GREEN)` — `lib/db/schema.ts` + `drizzle/0000_*.sql` + `drizzle/meta/*` + `npm run db:migrate` 적용
+   - (선택) `docs: #2 note tasks schema in CLAUDE.md §3` — 이미 반영돼 있으면 skip
+6. 계획서 markdown 출력 + 승인 요청.

--- a/.claude/skills/raise-pr/SKILL.md
+++ b/.claude/skills/raise-pr/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: raise-pr
+description: 이미 구현·커밋이 완료된 로컬 브랜치를 기준으로 PR을 생성하고, 이 프로젝트의 CI(`ci.yml`의 lint + vitest + build + Playwright e2e)를 통과시켜 리뷰 승인 대기까지 끌고 간다. 사용자가 "PR 올려줘", "raise pr", "PR 생성", "리뷰 요청", "이 브랜치로 PR" 등으로 요청할 때 호출한다. 이슈 분석·TDD 구현은 범위 밖(`plan-issue` 또는 자유 구현 흐름). 이 스킬은 push → PR 본문 작성 → CI 감시 → 실패 대응 → 이슈·PR 체크박스 갱신 → 머지 대기까지 일관되게 수행. `gh pr merge` 자동 실행은 하지 않음(사용자 승인 필요).
+---
+
+# raise-pr — 완료된 브랜치에서 PR을 올려 승인까지
+
+이 프로젝트(Next.js 14 + Chakra UI v3 + Drizzle + Supabase + Vitest + Playwright) 규약에 맞게, **구현이 끝난 로컬 브랜치를 받아 PR 라이프사이클**만 일관 처리한다.
+
+## 전제
+
+- 현재 로컬 브랜치에 필요한 커밋이 모두 있고, **미커밋 변경 없음**(`git status` 클린).
+- `main`에 비해 의미 있는 diff가 있음(`git log --oneline main..HEAD` 비어있지 않음).
+- `gh` CLI 인증 완료, 원격 `origin` 설정됨.
+- CLAUDE.md §9 규약(Conventional Commits, 이슈 번호 참조, 한국어 커밋) 준수한 커밋 구성.
+
+아직 구현이 다 안 됐다면 이 스킬이 아니라 `plan-issue` 또는 직접 구현 흐름을 먼저 마친다.
+
+## 언제 쓰는가
+
+- 브랜치 작업이 끝났고 PR로 올릴 차례
+- 올린 PR의 CI 실패 후 수정 push → 재검증 루프
+- PR과 이슈 체크박스 정합성 감사·갱신
+
+## Phase 1 — 사전 점검 (Push 전)
+
+### 1.1 현재 상태
+```bash
+git branch --show-current
+git status                           # 미커밋 없음 확인
+git log --oneline main..HEAD         # 커밋 목록 (Conventional Commits 형식인지 육안 확인)
+git diff --stat main...HEAD          # 파일 변경 요약
+```
+
+### 1.2 CLAUDE.md 규칙 점검
+
+- **한 PR = 한 논리 단위**. `git diff --name-only main...HEAD` 결과가 과도하게 크면(예: 20+ 파일이고 서로 다른 관심사가 섞임), 사용자에게 `x.1/x.2`로 분할을 **제안**한다. 단 부트스트랩/foundation류로 사전 합의된 경우는 예외.
+- **한 이슈 = 한 PR**. 커밋 메시지·브랜치명에 이슈 번호가 드러나야 함.
+- **금기사항(§10) 위반 스캔**:
+  - `.env.local` / `.env` / `supabase/.temp/` 가 diff에 들어갔는지 → 들어갔으면 즉시 중단하고 사용자에게 보고.
+  - service role key 문자열(`service_role`, `SUPABASE_SERVICE_ROLE_KEY`)이 클라이언트 번들 경로(`app/`, `components/`, `lib/supabase/client.ts`)에 들어갔는지 → 있으면 중단.
+  - `supabase migration new|db push|db reset` 이 scripts/문서에 제안됐는지 → 있으면 제거 제안.
+  - `lib/db/schema.ts`만 있고 `drizzle/*.sql`이 빠져 있으면 → `npm run db:generate` 커밋 누락. 먼저 생성/커밋하라고 요청.
+
+### 1.3 로컬 품질 게이트
+
+CLAUDE.md §6의 "검증" 순서에 맞춰 **순차 실행** (모두 통과해야 push):
+
+```bash
+npm run lint    # ESLint (next/core-web-vitals)
+npm test        # vitest (unit + contract)
+npm run build   # next build (production)
+```
+
+e2e는 무거우므로 기본 **옵션**. UI/라우팅이 바뀐 경우만:
+```bash
+npm run test:e2e
+```
+
+**UI 변경이 포함된 PR**이면 `manual-test` 스킬을 돌려 USER_JOURNEY 해당 시나리오의 스크린샷 증적을 확보한 뒤 본 스킬로 돌아오는 것을 권장.
+
+## Phase 2 — Push + PR 생성
+
+### 2.1 Push
+
+```bash
+git push -u origin <current-branch>
+```
+
+기존 PR이 있으면 자동으로 업데이트되고 CI 재실행. 없으면 신규 upstream.
+
+### 2.2 PR 본문 작성 (`/tmp/pr-body.md`)
+
+**표준 템플릿**
+
+```markdown
+Closes #<issue-num>
+
+## Summary
+- 1~3개 불릿: 무엇을 / 왜 (SPEC.md §<x> 근거 또는 USER_JOURNEY J<y> 시나리오 언급)
+
+## TDD 증적 (해당 시)
+- `test: #<N> ...` 커밋 → RED (실패 이유 한 줄)
+- `feat: #<N> ...` 커밋 → GREEN
+- (선택) `refactor: #<N> ...` 커밋 → 정리 포인트
+
+## Test plan
+- [x] `npm run lint` 로컬 초록불
+- [x] `npm test` 로컬 초록불 (N passed)
+- [x] `npm run build` 로컬 초록불
+- [ ] CI `lint-unit-build` 초록불 (PR 생성 직후 확인)
+- [ ] CI `e2e` 초록불
+- [ ] (스키마 변경 시) 로컬 `npm run db:migrate` 적용 확인
+- [ ] (UI 변경 시) `manual-test` 스크린샷 <첨부 경로>
+
+## 파일 변경 요약
+| # | 파일 | 구분 | 비고 |
+|---|---|---|---|
+| 1 | `lib/db/schema.ts` | 수정 | tasks 테이블 정의 |
+| 2 | `drizzle/0000_*.sql` | 신규(자동생성) | 커밋 대상 |
+| 3 | ... | | |
+
+## 관련 시나리오 (USER_JOURNEY.md)
+- **J1** 빈 상태에서 안내 문구와 `+ 작업 추가` 버튼 보임
+- **J2** 최상위 작업 추가
+
+## 주의 (있을 때만)
+- SPEC.md §9 범위 밖 기능을 건드리지 않았음을 명시
+- 스키마 변경 시 프로덕션 migrate는 `db-migrate.yml`이 `main` 머지 후 실행 — 이 PR은 로컬 적용만
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### 2.3 PR 생성
+
+```bash
+gh pr create \
+  --title "<type>(<area>): #<num> <요약 ≤70자>" \
+  --body-file /tmp/pr-body.md \
+  --base main
+```
+
+**제목 컨벤션** (CLAUDE.md §9):
+- `feat: #3 Task 생성 모달`
+- `fix: #11 Overdue 빗금 누락`
+- `ci: #9 PRODUCTION_DATABASE_URL guard 제거`
+- `chore: #13 스킬 4종 추가`
+- `docs: #2 SPEC 업데이트`
+- `refactor: #5 Task 편집 로직 분리`
+- `test: #1 bootstrap test harness`
+
+여러 이슈를 닫으려면 본문에 `Closes #A`, `Closes #B` 각각 줄 바꿈.
+
+반환된 **PR URL·번호를 기록**.
+
+## Phase 3 — CI 대기·실패 대응 루프
+
+### 3.1 감시
+
+이 프로젝트의 CI 잡 (`.github/workflows/ci.yml`):
+- `lint-unit-build` — `npm ci` → `npm run lint` → `npm test` → `npm run build`
+- `e2e` — Playwright chromium, 실패 시 `playwright-report` 아티팩트 업로드
+
+`db-migrate.yml`은 **`main` push에서만** 돌고 PR에서는 skip (가드됨).
+
+```bash
+gh pr checks <pr-num>
+```
+
+또는 `Monitor` 도구로 `until` 루프:
+```bash
+until out=$(gh pr checks <pr-num> 2>&1); \
+  echo "$out" | grep -qE "(pass|fail|cancelled)"; \
+  do sleep 8; done; echo "$out"
+```
+
+### 3.2 실패 시 원인 격리
+
+```bash
+gh run view <run-id> --log-failed \
+  | grep -E "FAIL|Error:|✘|Expected|Received|Module not found|Type error" \
+  | head -30
+```
+
+**원인별 대응**
+
+| 증상 | 대응 |
+|---|---|
+| `npm run lint` 실패 | `.eslintrc.json` 룰 위반 라인 수정. `any` 과다 사용 등은 진짜 타입으로 고치고 규칙을 풀지 마라. |
+| `vitest` 실패 | `build/reports` 대신 CI 로그에서 "expected/received" 차이 확인 → 테스트 또는 구현 중 어느 쪽이 맞는지 판단 (보통 RED 때 정의한 계약이 정답). |
+| `next build` 실패 | Server/Client 경계 오류(`'use client'` 누락 또는 `next/headers`를 client에서 import), 타입 오류. `lib/supabase/server.ts`를 client 컴포넌트에서 import한 경우가 흔함. |
+| `playwright e2e` flaky | `playwright-report` 아티팩트의 trace 확인. `npm run dev` cold start 타이밍이면 `webServer.timeout` 상향 또는 CI에서 `next start` 사용. |
+| `drizzle-kit` 관련 | `schema.ts` 수정 후 `drizzle/` 폴더 커밋 누락이 가장 흔함. `npm run db:generate` 실행 + 생성물 커밋. |
+
+### 3.3 수정 커밋 → 재검증
+
+- 메시지 컨벤션: `fix: #<N> CI lint 위반 수정` / `test: #<N> flaky e2e 방어 추가` / `chore: #<N> drizzle 메타 파일 커밋 누락 보정` 등.
+- `git push` → CI 자동 재실행 → Monitor 재가동 (PR 번호 그대로, 동일 PR 업데이트).
+
+## Phase 4 — 이슈 ↔ PR 적합성 감사
+
+### 4.1 이슈 체크박스 1:1 대조
+
+```bash
+gh issue view <num> --json body --jq '.body' > /tmp/issue-body-old.md
+```
+
+각 `- [ ]` 항목을 PR 구현 범위와 대조. 구현 완료 + 증적(테스트 경로/파일 경로) 확보한 것만 `[x]` 로 전환.
+
+### 4.2 이슈 본문 갱신
+
+```bash
+# /tmp/issue-body-new.md 편집 후
+gh issue edit <num> --body-file /tmp/issue-body-new.md
+```
+
+- 미완 항목은 **사실대로 `[ ]` 유지** + 짧은 각주 (*이후 이슈에서*, *로컬 검증 미완* 등)
+- 허위 체크 금지
+
+### 4.3 PR Test plan 갱신
+
+```bash
+gh pr view <pr-num> --json body --jq '.body' > /tmp/pr-body-old.md
+# 체크박스 [x] 전환 + CI run 링크 삽입 후
+gh pr edit <pr-num> --body-file /tmp/pr-body-new.md
+```
+
+## Phase 5 — 리뷰·승인·머지 대기
+
+### 5.1 머지는 사용자가 한다
+
+**Claude는 `gh pr merge` 자동 실행 금지.** 공유 상태(원격 main) 변경은 사용자 명시적 승인 필요.
+
+리뷰 코멘트가 있으면 해당 사항만 수정해 Phase 3부터 재진행.
+
+### 5.2 리뷰 받기
+
+옵션: PR CI가 초록불인 상태에서 **`/multi-agent-review <PR번호>`** 스킬을 돌려 세 관점 교차 검증 리포트를 받는 것을 권장. 이 스킬의 출력(P0/P1 개선안)을 반영해 추가 커밋을 올리면 이 스킬의 Phase 3 루프로 다시 들어감.
+
+### 5.3 머지 후 정리
+
+```bash
+git fetch origin --prune
+git checkout main && git pull --ff-only
+```
+
+머지된 이슈가 에픽성 상위 이슈의 체크박스 중 하나였다면 상위 이슈 체크박스도 `[x]`로 갱신.
+
+---
+
+## 가이드라인 (박스 요약)
+
+- **Push 전 필수 3가지**: 미커밋 없음 / 금기사항(§10) 스캔 통과 / `lint` + `test` + `build` 순차 초록불.
+- **금지 행동 (사용자 승인 없이 금지)**: `gh pr merge`, `git push --force`(대신 `--force-with-lease`만, 그것도 rebase 등 명시적 상황에서만), `git reset --hard`, `gh run cancel`, `--no-verify` 커밋/푸시.
+- **PR 본문 템플릿**: `Closes #N` → Summary → TDD 증적 → Test plan → 파일 표 → USER_JOURNEY 시나리오 → 주의 → Claude 푸터.
+- **CI pending 1~3분 정상**: `Monitor`의 `until` 루프로 감시. 짧은 `sleep` 체인 금지.
+- **실패 대응 원칙**: 룰/게이트를 느슨하게 하지 말고 **원인 수정**. 테스트 실패를 삭제/skip하지 말 것.
+- **허위 체크박스 금지**: 이슈·PR 본문 체크는 실제 구현·검증 기반으로만.
+
+## 이 프로젝트의 체크 지점 (빠른 참조)
+
+| 항목 | 명령 / 파일 |
+|---|---|
+| Lint | `npm run lint` → `next lint` |
+| Unit/contract | `npm test` → vitest (`tests/unit/**`, `tests/contract/**`) |
+| Build | `npm run build` → Next.js production |
+| e2e | `npm run test:e2e` → Playwright chromium |
+| DB 마이그레이션 (로컬) | `npm run db:migrate` |
+| CI workflow (PR) | `.github/workflows/ci.yml` — `lint-unit-build` + `e2e` |
+| CI workflow (main push) | `.github/workflows/db-migrate.yml` — `drizzle-kit migrate` on `PRODUCTION_DATABASE_URL` (가드됨) |
+
+## 다른 스킬과의 관계
+
+- **선행**: `plan-issue` — 이슈 분석·질문·계획 수립. 이 스킬은 그 결과 구현이 끝난 상태를 전제.
+- **옵션**: `manual-test` — UI 포함 변경이면 Phase 1 로컬 게이트나 Phase 4 증적 확보 시 사용.
+- **후속**: `multi-agent-review` — Phase 5 직전에 세 관점 리뷰 받고 P0/P1 반영.
+- **범위 밖**: `review` / `security-review` — 본 스킬은 자체 코드 리뷰 안 함.
+
+---
+
+## 실행 예시 — 이슈 #13 스킬 4종 PR
+
+```
+Phase 1: git status clean, 5 파일(+1 docs), lint/test/build 초록불
+Phase 2: push → gh pr create (Closes #13, 4개 스킬 + CLAUDE.md §11 요약)
+Phase 3: CI → lint-unit-build pass / e2e pass (스킬 파일은 CI 영향 없음)
+Phase 4: 이슈 #13 체크박스 5/6 → [x] (마지막 "수동 호출 확인"은 머지 후)
+Phase 5: 사용자 머지 대기 → 머지 후 main 동기화 + PR #12 rebase
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,10 @@ export default defineConfig({
 |---|---|
 | `/setup-dev-environment` | 로컬 의존성 진단 + 설치/가입/로그인 가이드 |
 | `/dev-server` | Supabase 컨테이너 + Next.js 개발 서버 기동 |
+| `/plan-issue` | 이슈 번호로 SPEC·USER_JOURNEY 근거 TDD 구현 계획 수립 (구현은 안 함) |
+| `/raise-pr` | 완료된 로컬 브랜치 push → PR 생성 → CI 감시 → 이슈 체크박스 갱신 |
+| `/multi-agent-review` | PR을 품질·보안·테스트 세 관점으로 병렬 리뷰 + 교차 검증 |
+| `/manual-test` | Playwright MCP로 USER_JOURNEY J1~J17 수동 회귀 + 스크린샷 증적 |
 
 ### 프로젝트 MCP (`.mcp.json`)
 


### PR DESCRIPTION
Closes #13

## Summary
- 메인 프로세스의 자기 코드 편향을 줄이기 위한 **세 관점 병렬 리뷰 스킬**(`multi-agent-review`)과, 이후 이슈 #2~#11 진행에서 반복적으로 쓸 **`plan-issue` / `raise-pr` / `manual-test`** 3종을 함께 도입.
- 참고 원본(https://github.com/marcosdeseul/dihisoft-claude-session/tree/main/.claude/skills)은 Spring Boot/Gradle/JaCoCo 기반이라, 이 프로젝트의 **Next.js 14 + Drizzle + Supabase + Vitest/Playwright + OMC 에이전트** 스택과 CLAUDE.md 규약(§6 스키마 변경 순서, §9 커밋 규칙, §10 금기, §1-B SPEC/USER_JOURNEY 우선)에 맞게 재작성.

## 커밋 흐름 (한 커밋 = 한 스킬)
- `chore: #13 add multi-agent-review skill`
- `chore: #13 add plan-issue skill`
- `chore: #13 add raise-pr skill`
- `chore: #13 add manual-test skill`
- `docs: #13 update CLAUDE.md §11 slash skills index`

## 각 스킬 요약
| 스킬 | 역할 | 호출 트리거 | 핵심 의존 |
|---|---|---|---|
| `/multi-agent-review [PR#]` | `code-reviewer` + `security-reviewer` + `test-engineer` 세 OMC 에이전트를 **한 메시지에서 병렬 호출** → 교차표 + P0~P3 개선안 정리 | "멀티 에이전트 리뷰", "세 관점 리뷰" 등 | OMC 에이전트 3종 |
| `/plan-issue <issue#>` | 이슈를 읽고 `SPEC.md`/`USER_JOURNEY.md` 근거로 TDD 슬라이스(RED→GREEN→REFACTOR) 커밋 계획 수립 (구현은 안 함) | "이슈 #N 계획" 등 | `gh`, SPEC, USER_JOURNEY |
| `/raise-pr` | 완료된 로컬 브랜치를 push → PR 생성 → `ci.yml`(lint+test+build+e2e) 감시 → 이슈 체크박스 갱신 | "PR 올려줘" 등 | `gh`, `ci.yml` |
| `/manual-test [J#]` | Playwright MCP로 `USER_JOURNEY.md` J1~J17 시나리오 수동 회귀 + `<scenario-id>-<state>.png` 스크린샷 증적 | "J3 브라우저 확인" 등 | Playwright MCP, `USER_JOURNEY.md` |

## 설계 원칙
- **메인 세션의 편향 완화**: 리뷰는 별도 에이전트가 수행. 세 관점이 동시에 지적한 항목만 진짜 블로커로 취급.
- **스킬 간 역할 비중복**: `plan-issue`는 계획만, `raise-pr`는 PR 라이프사이클만, `multi-agent-review`는 리뷰만, `manual-test`는 수동 검증만. "범위 밖" 섹션으로 경계 명시.
- **CLAUDE.md 규약 일관 참조**: 각 스킬이 §6(스키마 변경 순서) / §9(Conventional Commits) / §10(금기) / §1-B(SPEC 우선)를 명시적으로 인용.

## Test plan
- [x] 4개 스킬 모두 frontmatter `name`/`description`으로 Claude Code 세션에 등록됨 (이번 세션에서 스킬 리스트 재로드 시 4개 모두 `user-invocable skills`에 나타남을 육안 확인)
- [x] `git ls-tree -r HEAD` 로 스킬 6개(`dev-server`, `setup-dev-environment` + 신규 4종) 모두 추적 확인
- [ ] 머지 후 PR #12 rebase 테스트 — `feat/issue-1-bootstrap` 브랜치를 새 main에 rebase 시 `.claude/skills/**` 충돌 없을 것(파일 집합 disjoint), `CLAUDE.md`는 §11 영역 양쪽이 같은 표를 수정하므로 3-way merge 필요 가능성 있음
- [ ] (머지 후 도그푸딩) `/multi-agent-review 12` 호출 → 이번 세션에서 수기로 한 종합 리뷰와 동일한 구조/유사한 결론이 나오는지 비교

## 파일 변경 요약
| # | 파일 | 구분 | 용량 |
|---|---|---|---|
| 1 | `.claude/skills/multi-agent-review/SKILL.md` | 신규 | 215줄 |
| 2 | `.claude/skills/plan-issue/SKILL.md` | 신규 | 197줄 |
| 3 | `.claude/skills/raise-pr/SKILL.md` | 신규 | 269줄 |
| 4 | `.claude/skills/manual-test/SKILL.md` | 신규 | 174줄 |
| 5 | `CLAUDE.md` | 수정 | §11 슬래시 스킬 표에 4줄 추가 |

## 주의
- 이 PR은 `main`에 아직 `package.json`·`ci.yml`이 없는 상태(이슈 #1 부트스트랩이 PR #12에서 대기 중)이므로 **CI 잡이 실행되지 않는다**. 변경은 전부 `.claude/skills/**/*.md`와 `CLAUDE.md` 문서여서 lint/build/test 대상도 아님.
- 머지 후: PR #12(`feat/issue-1-bootstrap`)를 새 `main`에 rebase → `CLAUDE.md` §11 표가 겹치면 3-way merge로 두 변경을 모두 보존 → force-with-lease push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
