### PR TITLE
feat: #2 #3 tasks 스키마 정의 + Task 생성/수정/삭제 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,22 @@ jobs:
     name: playwright e2e (chromium)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
     steps:
       - uses: actions/checkout@v4
 
@@ -57,6 +73,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run DB migrations
+        run: npm run db:migrate
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Write .env.local for CI
+        run: echo "DATABASE_URL=$DATABASE_URL" > .env.local
+
       - name: Run DB migrations
         run: npm run db:migrate
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ coverage/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/.playwright-mcp/
 
 # ── Logs ──────────────────────────────────────────────────
 npm-debug.log*

--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -18,13 +18,45 @@ export type TaskFormData = {
 
 export type ActionResult = { success: true } | { success: false; error: string };
 
+const STATUS_VALUES = ['todo', 'doing', 'done'] as const;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function validate(data: TaskFormData): string | null {
+  const title = data.title?.trim() ?? '';
+  if (title.length === 0) return '제목을 입력해 주세요.';
+  if (title.length > 200) return '제목은 200자 이내로 입력해 주세요.';
+
+  if (data.description && data.description.length > 2000)
+    return '설명은 2000자 이내로 입력해 주세요.';
+  if (data.assignee && data.assignee.length > 100)
+    return '담당자는 100자 이내로 입력해 주세요.';
+
+  if (data.status !== undefined && !STATUS_VALUES.includes(data.status))
+    return '유효하지 않은 상태 값입니다.';
+
+  if (data.progress !== undefined) {
+    if (!Number.isInteger(data.progress) || data.progress < 0 || data.progress > 100)
+      return '진행률은 0~100 사이의 정수여야 합니다.';
+  }
+
+  if (data.startDate && !DATE_RE.test(data.startDate))
+    return '시작일 형식이 올바르지 않습니다.';
+  if (data.dueDate && !DATE_RE.test(data.dueDate))
+    return '목표 기한 형식이 올바르지 않습니다.';
+  if (data.startDate && data.dueDate && data.startDate > data.dueDate)
+    return '목표 기한은 시작일 이후여야 합니다.';
+
+  if (data.parentId && !UUID_RE.test(data.parentId))
+    return '상위 작업 ID가 올바르지 않습니다.';
+
+  return null;
+}
+
 export async function createTask(data: TaskFormData): Promise<ActionResult> {
-  if (!data.title.trim()) {
-    return { success: false, error: '제목을 입력해 주세요.' };
-  }
-  if (data.startDate && data.dueDate && data.startDate > data.dueDate) {
-    return { success: false, error: '목표 기한은 시작일 이후여야 합니다.' };
-  }
+  const err = validate(data);
+  if (err) return { success: false, error: err };
   try {
     const db = getDb();
     await db.insert(tasks).values({
@@ -39,7 +71,8 @@ export async function createTask(data: TaskFormData): Promise<ActionResult> {
     });
     revalidatePath('/');
     return { success: true };
-  } catch {
+  } catch (err) {
+    console.error('[createTask] failed', { msg: (err as Error).message });
     return { success: false, error: '작업 생성에 실패했습니다.' };
   }
 }
@@ -48,12 +81,9 @@ export async function updateTask(
   id: string,
   data: TaskFormData,
 ): Promise<ActionResult> {
-  if (!data.title.trim()) {
-    return { success: false, error: '제목을 입력해 주세요.' };
-  }
-  if (data.startDate && data.dueDate && data.startDate > data.dueDate) {
-    return { success: false, error: '목표 기한은 시작일 이후여야 합니다.' };
-  }
+  if (!UUID_RE.test(id)) return { success: false, error: '작업 ID가 올바르지 않습니다.' };
+  const err = validate(data);
+  if (err) return { success: false, error: err };
   try {
     const db = getDb();
     await db
@@ -71,12 +101,14 @@ export async function updateTask(
       .where(eq(tasks.id, id));
     revalidatePath('/');
     return { success: true };
-  } catch {
+  } catch (err) {
+    console.error('[updateTask] failed', { msg: (err as Error).message });
     return { success: false, error: '작업 수정에 실패했습니다.' };
   }
 }
 
 export async function deleteTask(id: string): Promise<ActionResult> {
+  if (!UUID_RE.test(id)) return { success: false, error: '작업 ID가 올바르지 않습니다.' };
   try {
     const db = getDb();
     await db.delete(tasks).where(eq(tasks.id, id));
@@ -84,7 +116,8 @@ export async function deleteTask(id: string): Promise<ActionResult> {
     // 이유: revalidatePath 가 즉시 DOM을 갱신하면 다이얼로그 focus-trap 정리 전에
     // 트리거 요소(삭제 버튼)가 사라져 "@zag-js/focus-trap" 에러가 발생한다.
     return { success: true };
-  } catch {
+  } catch (err) {
+    console.error('[deleteTask] failed', { msg: (err as Error).message });
     return { success: false, error: '작업 삭제에 실패했습니다.' };
   }
 }

--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -1,0 +1,100 @@
+'use server';
+
+import { getDb } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+
+export type TaskFormData = {
+  title: string;
+  description?: string | null;
+  assignee?: string | null;
+  status?: 'todo' | 'doing' | 'done';
+  progress?: number;
+  startDate?: string | null;
+  dueDate?: string | null;
+  parentId?: string | null;
+};
+
+export type ActionResult = { success: true } | { success: false; error: string };
+
+export async function createTask(data: TaskFormData): Promise<ActionResult> {
+  if (!data.title.trim()) {
+    return { success: false, error: '제목을 입력해 주세요.' };
+  }
+  if (data.startDate && data.dueDate && data.startDate > data.dueDate) {
+    return { success: false, error: '목표 기한은 시작일 이후여야 합니다.' };
+  }
+  try {
+    const db = getDb();
+    await db.insert(tasks).values({
+      title: data.title.trim(),
+      description: data.description ?? null,
+      assignee: data.assignee ?? null,
+      status: data.status ?? 'todo',
+      progress: data.progress ?? 0,
+      startDate: data.startDate ?? null,
+      dueDate: data.dueDate ?? null,
+      parentId: data.parentId ?? null,
+    });
+    revalidatePath('/');
+    return { success: true };
+  } catch {
+    return { success: false, error: '작업 생성에 실패했습니다.' };
+  }
+}
+
+export async function updateTask(
+  id: string,
+  data: TaskFormData,
+): Promise<ActionResult> {
+  if (!data.title.trim()) {
+    return { success: false, error: '제목을 입력해 주세요.' };
+  }
+  if (data.startDate && data.dueDate && data.startDate > data.dueDate) {
+    return { success: false, error: '목표 기한은 시작일 이후여야 합니다.' };
+  }
+  try {
+    const db = getDb();
+    await db
+      .update(tasks)
+      .set({
+        title: data.title.trim(),
+        description: data.description ?? null,
+        assignee: data.assignee ?? null,
+        status: data.status ?? 'todo',
+        progress: data.progress ?? 0,
+        startDate: data.startDate ?? null,
+        dueDate: data.dueDate ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(tasks.id, id));
+    revalidatePath('/');
+    return { success: true };
+  } catch {
+    return { success: false, error: '작업 수정에 실패했습니다.' };
+  }
+}
+
+export async function deleteTask(id: string): Promise<ActionResult> {
+  try {
+    const db = getDb();
+    await db.delete(tasks).where(eq(tasks.id, id));
+    // revalidatePath 를 생략하고 클라이언트에서 router.refresh() 로 대체한다.
+    // 이유: revalidatePath 가 즉시 DOM을 갱신하면 다이얼로그 focus-trap 정리 전에
+    // 트리거 요소(삭제 버튼)가 사라져 "@zag-js/focus-trap" 에러가 발생한다.
+    return { success: true };
+  } catch {
+    return { success: false, error: '작업 삭제에 실패했습니다.' };
+  }
+}
+
+// 삭제 확인 다이얼로그의 동적 문구("하위 작업 N개가…")용
+export async function countChildren(parentId: string): Promise<number> {
+  const db = getDb();
+  const children = await db
+    .select({ id: tasks.id })
+    .from(tasks)
+    .where(eq(tasks.parentId, parentId));
+  return children.length;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,19 @@
 import { Container, Heading } from '@chakra-ui/react';
+import { asc } from 'drizzle-orm';
+import { getDb } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
+import { TaskList } from '@/components/task-list';
 
-export default function HomePage() {
+export default async function HomePage() {
+  const db = getDb();
+  const allTasks = await db.select().from(tasks).orderBy(asc(tasks.createdAt));
+
   return (
-    <Container maxW="3xl" py={16}>
-      <Heading as="h1" size="2xl">
+    <Container maxW="5xl" py={8}>
+      <Heading as="h1" size="2xl" mb={6}>
         WBS
       </Heading>
+      <TaskList tasks={allTasks} />
     </Container>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,8 @@ import { getDb } from '@/lib/db';
 import { tasks } from '@/lib/db/schema';
 import { TaskList } from '@/components/task-list';
 
+export const dynamic = 'force-dynamic';
+
 export default async function HomePage() {
   const db = getDb();
   const allTasks = await db.select().from(tasks).orderBy(asc(tasks.createdAt));

--- a/components/delete-confirm-dialog.tsx
+++ b/components/delete-confirm-dialog.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Button, Dialog, Portal, Text } from '@chakra-ui/react';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { deleteTask } from '@/app/actions/tasks';
+import type { Task } from '@/lib/types';
+
+interface DeleteConfirmDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  task: Task | null;
+  childCount: number;
+}
+
+export function DeleteConfirmDialog({
+  isOpen,
+  onClose,
+  task,
+  childCount,
+}: DeleteConfirmDialogProps) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleDelete = async () => {
+    if (!task) return;
+    setLoading(true);
+    await deleteTask(task.id);
+    setLoading(false);
+    onClose();
+    // 다이얼로그 close 애니메이션(~200ms)이 끝난 뒤 DOM을 갱신해
+    // focus-trap 정리 전에 트리거 요소가 사라지는 문제를 방지한다.
+    setTimeout(() => router.refresh(), 300);
+  };
+
+  const message =
+    childCount > 0
+      ? `'${task?.title}' 작업과 하위 작업 ${childCount}개가 함께 삭제됩니다. 계속하시겠습니까?`
+      : `'${task?.title}' 작업을 삭제하시겠습니까?`;
+
+  return (
+    <Dialog.Root
+      role="alertdialog"
+      lazyMount
+      unmountOnExit
+      open={isOpen}
+      onOpenChange={(e) => {
+        if (!e.open) onClose();
+      }}
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>작업 삭제</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Text>{message}</Text>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Button variant="outline" onClick={onClose}>
+                취소
+              </Button>
+              <Button colorPalette="red" loading={loading} onClick={handleDelete}>
+                삭제
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/task-form-modal.tsx
+++ b/components/task-form-modal.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import {
+  Button,
+  CloseButton,
+  Dialog,
+  Field,
+  Input,
+  NativeSelect,
+  NumberInput,
+  Portal,
+  Stack,
+  Text,
+  Textarea,
+} from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import { createTask, updateTask, type TaskFormData } from '@/app/actions/tasks';
+import type { Task } from '@/lib/types';
+
+interface TaskFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  task?: Task;
+}
+
+export function TaskFormModal({ isOpen, onClose, task }: TaskFormModalProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [assignee, setAssignee] = useState('');
+  const [status, setStatus] = useState<'todo' | 'doing' | 'done'>('todo');
+  const [progress, setProgress] = useState('0');
+  const [startDate, setStartDate] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTitle(task?.title ?? '');
+      setDescription(task?.description ?? '');
+      setAssignee(task?.assignee ?? '');
+      setStatus((task?.status as 'todo' | 'doing' | 'done') ?? 'todo');
+      setProgress(String(task?.progress ?? 0));
+      setStartDate(task?.startDate ?? '');
+      setDueDate(task?.dueDate ?? '');
+      setError('');
+    }
+  }, [isOpen, task]);
+
+  const handleSubmit = async () => {
+    setError('');
+    if (!title.trim()) {
+      setError('제목을 입력해 주세요.');
+      return;
+    }
+    if (startDate && dueDate && startDate > dueDate) {
+      setError('목표 기한은 시작일 이후여야 합니다.');
+      return;
+    }
+
+    setLoading(true);
+    const data: TaskFormData = {
+      title,
+      description: description || null,
+      assignee: assignee || null,
+      status,
+      progress: Number(progress) || 0,
+      startDate: startDate || null,
+      dueDate: dueDate || null,
+    };
+
+    const result = task ? await updateTask(task.id, data) : await createTask(data);
+    setLoading(false);
+
+    if (!result.success) {
+      setError(result.error);
+      return;
+    }
+    onClose();
+  };
+
+  const hasDateError = !!(startDate && dueDate && startDate > dueDate);
+
+  return (
+    <Dialog.Root
+      lazyMount
+      unmountOnExit
+      open={isOpen}
+      onOpenChange={(e) => {
+        if (!e.open) onClose();
+      }}
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>{task ? '작업 수정' : '작업 추가'}</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.CloseTrigger asChild>
+              <CloseButton size="sm" />
+            </Dialog.CloseTrigger>
+            <Dialog.Body pb={6}>
+              <Stack gap={4}>
+                {error && (
+                  <Text color="red.500" fontSize="sm">
+                    {error}
+                  </Text>
+                )}
+                <Field.Root required>
+                  <Field.Label>
+                    제목 <Field.RequiredIndicator />
+                  </Field.Label>
+                  <Input
+                    placeholder="작업 제목"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                  />
+                </Field.Root>
+                <Field.Root>
+                  <Field.Label>설명</Field.Label>
+                  <Textarea
+                    placeholder="작업 설명"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    rows={3}
+                  />
+                </Field.Root>
+                <Field.Root>
+                  <Field.Label>담당자</Field.Label>
+                  <Input
+                    placeholder="담당자 이름"
+                    value={assignee}
+                    onChange={(e) => setAssignee(e.target.value)}
+                  />
+                </Field.Root>
+                <Field.Root>
+                  <Field.Label>상태</Field.Label>
+                  <NativeSelect.Root>
+                    <NativeSelect.Field
+                      value={status}
+                      onChange={(e) =>
+                        setStatus(e.target.value as 'todo' | 'doing' | 'done')
+                      }
+                    >
+                      <option value="todo">할 일</option>
+                      <option value="doing">진행 중</option>
+                      <option value="done">완료</option>
+                    </NativeSelect.Field>
+                    <NativeSelect.Indicator />
+                  </NativeSelect.Root>
+                </Field.Root>
+                <Field.Root>
+                  <Field.Label>진행률 (0~100)</Field.Label>
+                  <NumberInput.Root
+                    min={0}
+                    max={100}
+                    value={progress}
+                    onValueChange={(e) => setProgress(e.value)}
+                    width="100%"
+                  >
+                    <NumberInput.Control />
+                    <NumberInput.Input />
+                  </NumberInput.Root>
+                </Field.Root>
+                <Field.Root invalid={hasDateError}>
+                  <Field.Label>시작일</Field.Label>
+                  <Input
+                    type="date"
+                    value={startDate}
+                    onChange={(e) => setStartDate(e.target.value)}
+                  />
+                </Field.Root>
+                <Field.Root invalid={hasDateError}>
+                  <Field.Label>목표 기한</Field.Label>
+                  <Input
+                    type="date"
+                    value={dueDate}
+                    onChange={(e) => setDueDate(e.target.value)}
+                  />
+                  {hasDateError && (
+                    <Field.ErrorText>
+                      목표 기한은 시작일 이후여야 합니다.
+                    </Field.ErrorText>
+                  )}
+                </Field.Root>
+              </Stack>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Button variant="outline" onClick={onClose}>
+                취소
+              </Button>
+              <Button colorPalette="blue" loading={loading} onClick={handleSubmit}>
+                {task ? '수정' : '추가'}
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { Box, Button, HStack, Table, Text } from '@chakra-ui/react';
+import { useState } from 'react';
+import { TaskRow } from './task-row';
+import { TaskFormModal } from './task-form-modal';
+import { DeleteConfirmDialog } from './delete-confirm-dialog';
+import { countChildren } from '@/app/actions/tasks';
+import type { Task } from '@/lib/types';
+
+interface TaskListProps {
+  tasks: Task[];
+}
+
+export function TaskList({ tasks }: TaskListProps) {
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingTask, setEditingTask] = useState<Task | undefined>(undefined);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [deletingTask, setDeletingTask] = useState<Task | null>(null);
+  const [childCount, setChildCount] = useState(0);
+
+  const handleAddClick = () => {
+    setEditingTask(undefined);
+    setIsFormOpen(true);
+  };
+
+  const handleEditClick = (task: Task) => {
+    setEditingTask(task);
+    setIsFormOpen(true);
+  };
+
+  const handleDeleteClick = async (task: Task) => {
+    setDeletingTask(task);
+    const count = await countChildren(task.id);
+    setChildCount(count);
+    setIsDeleteOpen(true);
+  };
+
+  const handleFormClose = () => {
+    setIsFormOpen(false);
+    setEditingTask(undefined);
+  };
+
+  const handleDeleteClose = () => {
+    setIsDeleteOpen(false);
+    setDeletingTask(null);
+    setChildCount(0);
+  };
+
+  return (
+    <Box>
+      <HStack mb={4} gap={2}>
+        <Button size="sm" colorPalette="blue" onClick={handleAddClick}>
+          + 작업 추가
+        </Button>
+        <Button size="sm" variant="outline" disabled>
+          CSV 내보내기
+        </Button>
+        <Button size="sm" variant="outline" disabled>
+          CSV 불러오기
+        </Button>
+      </HStack>
+
+      {tasks.length === 0 ? (
+        <Box textAlign="center" py={16} color="gray.500">
+          <Text fontSize="lg">아직 작업이 없습니다.</Text>
+          <Text fontSize="sm" mt={2}>
+            + 작업 추가로 시작해 보세요.
+          </Text>
+        </Box>
+      ) : (
+        <Table.Root size="sm" variant="line">
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeader>제목</Table.ColumnHeader>
+              <Table.ColumnHeader>담당자</Table.ColumnHeader>
+              <Table.ColumnHeader>상태</Table.ColumnHeader>
+              <Table.ColumnHeader>진행률</Table.ColumnHeader>
+              <Table.ColumnHeader>시작일</Table.ColumnHeader>
+              <Table.ColumnHeader>기한</Table.ColumnHeader>
+              <Table.ColumnHeader />
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {tasks.map((task) => (
+              <TaskRow
+                key={task.id}
+                task={task}
+                onEdit={handleEditClick}
+                onDelete={handleDeleteClick}
+              />
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
+
+      {isFormOpen && (
+        <TaskFormModal
+          key={editingTask?.id ?? 'new'}
+          isOpen={isFormOpen}
+          onClose={handleFormClose}
+          task={editingTask}
+        />
+      )}
+
+      {isDeleteOpen && (
+        <DeleteConfirmDialog
+          isOpen={isDeleteOpen}
+          onClose={handleDeleteClose}
+          task={deletingTask}
+          childCount={childCount}
+        />
+      )}
+    </Box>
+  );
+}

--- a/components/task-row.tsx
+++ b/components/task-row.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Badge, Button, HStack, Table } from '@chakra-ui/react';
+import type { Task } from '@/lib/types';
+
+const STATUS_CONFIG = {
+  todo: { label: '할 일', colorPalette: 'gray' },
+  doing: { label: '진행 중', colorPalette: 'blue' },
+  done: { label: '완료', colorPalette: 'green' },
+} as const;
+
+interface TaskRowProps {
+  task: Task;
+  onEdit: (task: Task) => void;
+  onDelete: (task: Task) => void;
+}
+
+export function TaskRow({ task, onEdit, onDelete }: TaskRowProps) {
+  const statusConfig =
+    STATUS_CONFIG[task.status as keyof typeof STATUS_CONFIG] ??
+    STATUS_CONFIG.todo;
+
+  return (
+    <Table.Row>
+      <Table.Cell>{task.title}</Table.Cell>
+      <Table.Cell>{task.assignee ?? '-'}</Table.Cell>
+      <Table.Cell>
+        <Badge colorPalette={statusConfig.colorPalette} size="sm">
+          {statusConfig.label}
+        </Badge>
+      </Table.Cell>
+      <Table.Cell>{task.progress}%</Table.Cell>
+      <Table.Cell>{task.startDate ?? '-'}</Table.Cell>
+      <Table.Cell>{task.dueDate ?? '-'}</Table.Cell>
+      <Table.Cell>
+        <HStack gap={2}>
+          <Button size="xs" variant="outline" onClick={() => onEdit(task)}>
+            편집
+          </Button>
+          <Button
+            size="xs"
+            variant="outline"
+            colorPalette="red"
+            onClick={() => onDelete(task)}
+          >
+            삭제
+          </Button>
+        </HStack>
+      </Table.Cell>
+    </Table.Row>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,15 @@
+export type TaskStatus = 'todo' | 'doing' | 'done';
+
+export type Task = {
+  id: string;
+  parentId: string | null;
+  title: string;
+  description: string | null;
+  assignee: string | null;
+  status: string;
+  progress: number;
+  startDate: string | null;
+  dueDate: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
 };
 
 export default nextConfig;

--- a/tests/e2e/J17-date-validation.spec.ts
+++ b/tests/e2e/J17-date-validation.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('J17 — 시작일 > 목표 기한 검증', () => {
+  test('시작일이 목표 기한보다 늦으면 에러 메시지가 표시되고 저장이 되지 않는다', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await page.getByPlaceholder('작업 제목').fill('날짜 검증 테스트');
+    await page.locator('input[type="date"]').nth(0).fill('2025-12-31');
+    await page.locator('input[type="date"]').nth(1).fill('2025-01-01');
+
+    await page.getByRole('button', { name: '추가' }).click();
+
+    // 에러 메시지 표시
+    await expect(
+      page.getByText('목표 기한은 시작일 이후여야 합니다.'),
+    ).toBeVisible();
+    // 다이얼로그는 닫히지 않는다
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+
+  test('시작일과 목표 기한이 동일하면 저장된다', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    const taskTitle = `J17 동일 날짜 ${Date.now()}`;
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.locator('input[type="date"]').nth(0).fill('2025-06-01');
+    await page.locator('input[type="date"]').nth(1).fill('2025-06-01');
+
+    await page.getByRole('button', { name: '추가' }).click();
+
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await expect(page.getByText(taskTitle)).toBeVisible();
+  });
+});

--- a/tests/e2e/J17-date-validation.spec.ts
+++ b/tests/e2e/J17-date-validation.spec.ts
@@ -17,7 +17,7 @@ test.describe('J17 — 시작일 > 목표 기한 검증', () => {
 
     // 에러 메시지 표시
     await expect(
-      page.getByText('목표 기한은 시작일 이후여야 합니다.'),
+      page.getByText('목표 기한은 시작일 이후여야 합니다.').first(),
     ).toBeVisible();
     // 다이얼로그는 닫히지 않는다
     await expect(page.getByRole('dialog')).toBeVisible();

--- a/tests/e2e/J2-first-task.spec.ts
+++ b/tests/e2e/J2-first-task.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('J2 — 첫 최상위 작업 추가', () => {
+  test('+ 작업 추가 버튼으로 제목 입력 후 저장하면 목록에 나타난다', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    const taskTitle = `J2 테스트 작업 ${Date.now()}`;
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.getByRole('button', { name: '추가' }).click();
+
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await expect(page.getByText(taskTitle)).toBeVisible();
+  });
+
+  test('제목 없이 저장하면 에러 메시지가 표시된다', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByText('제목을 입력해 주세요.')).toBeVisible();
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+});

--- a/tests/e2e/J7-edit-title.spec.ts
+++ b/tests/e2e/J7-edit-title.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('J7 — 제목 수정 즉시 반영', () => {
+  test('편집 버튼으로 제목을 변경하면 목록에 즉시 반영된다', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // 테스트용 작업 생성
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    const originalTitle = `J7 원본 ${Date.now()}`;
+    await page.getByPlaceholder('작업 제목').fill(originalTitle);
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByText(originalTitle)).toBeVisible();
+
+    // 해당 행의 편집 버튼 클릭
+    const row = page.getByRole('row').filter({ hasText: originalTitle });
+    await row.getByRole('button', { name: '편집' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    // 제목 수정
+    const updatedTitle = `J7 수정됨 ${Date.now()}`;
+    const titleInput = page.getByPlaceholder('작업 제목');
+    await titleInput.clear();
+    await titleInput.fill(updatedTitle);
+    await page.getByRole('button', { name: '수정' }).click();
+
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await expect(page.getByText(updatedTitle)).toBeVisible();
+    await expect(page.getByText(originalTitle)).not.toBeVisible();
+  });
+});

--- a/tests/e2e/J8-delete-with-children.spec.ts
+++ b/tests/e2e/J8-delete-with-children.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('J8 — 하위 포함 삭제', () => {
+  test('삭제 버튼 클릭 시 확인 다이얼로그가 표시된다', async ({ page }) => {
+    await page.goto('/');
+
+    // 테스트용 작업 생성
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    const taskTitle = `J8 삭제 대상 ${Date.now()}`;
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByText(taskTitle)).toBeVisible();
+
+    // 삭제 버튼 클릭
+    const row = page.getByRole('row').filter({ hasText: taskTitle });
+    await row.getByRole('button', { name: '삭제' }).click();
+
+    // 확인 다이얼로그 표시
+    await expect(page.getByRole('alertdialog')).toBeVisible();
+    // 하위 없음 → 단순 메시지
+    await expect(
+      page.getByText(`'${taskTitle}' 작업을 삭제하시겠습니까?`),
+    ).toBeVisible();
+  });
+
+  test('삭제 확인 후 목록에서 사라진다', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    const taskTitle = `J8 삭제됨 ${Date.now()}`;
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByText(taskTitle)).toBeVisible();
+
+    const row = page.getByRole('row').filter({ hasText: taskTitle });
+    await row.getByRole('button', { name: '삭제' }).click();
+    await expect(page.getByRole('alertdialog')).toBeVisible();
+
+    // 삭제 확인 버튼 (alertdialog 내 빨간 삭제 버튼)
+    await page
+      .getByRole('alertdialog')
+      .getByRole('button', { name: '삭제' })
+      .click();
+
+    await expect(page.getByRole('alertdialog')).not.toBeVisible();
+    await expect(page.getByText(taskTitle)).not.toBeVisible();
+  });
+
+  // TODO: 하위 작업 생성 UI가 추가되면(#4) "하위 작업 N개" 문구 테스트 추가
+});


### PR DESCRIPTION
Closes #2
Closes #3

## Summary
- SPEC.md §A~§D 기준 Task CRUD 전체 구현 (목록·생성·수정·삭제)
- Server Action 경유 Drizzle 쿼리 (`app/actions/tasks.ts`), 클라이언트에서 DB 직접 접근 없음
- 삭제 시 하위 작업 수 동적 문구, 날짜 역순 유효성 검사(J17) 클라이언트·서버 이중 방어

## TDD 증적

| 커밋 | 단계 | 내용 |
|---|---|---|
| `test: #2 tasks 스키마 통합 테스트` | RED | `schema-tasks.test.ts` — DB 스키마 검증 (14개 테스트) |
| `feat: #2 tasks 스키마 정의 + 0000 마이그레이션` | GREEN | `lib/db/schema.ts` + Drizzle 마이그레이션 |
| `fix: #2 통합 테스트 하네스 + db:* 스크립트 보완` | REFACTOR | vitest config 분리, `package.json` 스크립트 정비 |
| `feat: #3 Task 생성/수정/삭제 구현` | GREEN | 4개 컴포넌트 + Server Action + E2E 테스트 |

## Test plan
- [x] `npm run lint` 로컬 초록불 (0 warnings)
- [x] `npm test` 로컬 초록불 (14 passed)
- [x] `npm run build` 로컬 초록불
- [x] CI `lint-unit-build` 초록불 ✅ run#24977526897
- [x] CI `e2e` 초록불 ✅ run#24977526897

## 파일 변경 요약
| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `lib/db/schema.ts` | 신규 | tasks 테이블 정의 (Drizzle DSL) |
| 2 | `drizzle/0000_optimal_silvermane.sql` | 신규(자동생성) | CREATE TABLE tasks |
| 3 | `drizzle/meta/` | 신규(자동생성) | Drizzle 메타 |
| 4 | `app/actions/tasks.ts` | 신규 | createTask / updateTask / deleteTask / countChildren |
| 5 | `app/page.tsx` | 수정 | DB 조회 + TaskList 렌더링 (Server Component) |
| 6 | `components/task-list.tsx` | 신규 | 목록 테이블, 빈 상태, 툴바 |
| 7 | `components/task-row.tsx` | 신규 | 행 렌더링, 상태 배지, 편집/삭제 버튼 |
| 8 | `components/task-form-modal.tsx` | 신규 | 생성·수정 폼 (날짜 유효성 포함) |
| 9 | `components/delete-confirm-dialog.tsx` | 신규 | 삭제 확인 (하위 N개 동적 문구) |
| 10 | `lib/types.ts` | 신규 | 클라이언트용 Task 타입 |
| 11 | `next.config.mjs` | 수정 | reactStrictMode: false |
| 12 | `tests/e2e/J2,J7,J8,J17.spec.ts` | 신규 | Playwright E2E 4종 |
| 13 | `tests/integration/schema-tasks.test.ts` | 신규 | Drizzle 스키마 통합 테스트 |

## 관련 시나리오 (USER_JOURNEY.md)
- **J1** 빈 상태에서 안내 문구와 `+ 작업 추가` 버튼 노출
- **J2** 최상위 작업 추가 후 목록 반영
- **J7** 제목 수정 즉시 반영
- **J8** 삭제 확인 다이얼로그 문구 + 삭제 실행
- **J17** 시작일 > 기한이면 저장 실패 + 에러 메시지

## 주의
- `reactStrictMode: false`: Chakra UI v3 / @zag-js/focus-trap가 React 18 Strict Mode의 effect 이중 호출과 충돌하는 알려진 문제. 프로덕션 동작에는 영향 없음.
- `deleteTask`에서 `revalidatePath` 제거 후 `router.refresh()`(300ms delay) 사용 — focus-trap 정리 순서 보장 workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

