### PR TITLE
feat: #5 진행률·상태 편집 규칙 — 배지 순환 + 진행률 100 → 자동 완료

### DIFF
--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -4,6 +4,8 @@ import { getDb } from '@/lib/db';
 import { tasks } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
+import { deriveStatusFromProgress } from '@/lib/tasks/derive-status';
+import type { TaskStatus } from '@/lib/types';
 
 export type TaskFormData = {
   title: string;
@@ -68,12 +70,14 @@ export async function createTask(data: TaskFormData): Promise<ActionResult> {
       return { success: false, error: '상위 작업을 찾을 수 없습니다.' };
   }
   try {
+    const progress = data.progress ?? 0;
+    const status = deriveStatusFromProgress(progress, (data.status ?? 'todo') as TaskStatus);
     await db.insert(tasks).values({
       title: data.title.trim(),
       description: data.description ?? null,
       assignee: data.assignee ?? null,
-      status: data.status ?? 'todo',
-      progress: data.progress ?? 0,
+      status,
+      progress,
       startDate: data.startDate ?? null,
       dueDate: data.dueDate ?? null,
       parentId: data.parentId ?? null,
@@ -95,14 +99,16 @@ export async function updateTask(
   if (err) return { success: false, error: err };
   try {
     const db = getDb();
+    const progress = data.progress ?? 0;
+    const status = deriveStatusFromProgress(progress, (data.status ?? 'todo') as TaskStatus);
     await db
       .update(tasks)
       .set({
         title: data.title.trim(),
         description: data.description ?? null,
         assignee: data.assignee ?? null,
-        status: data.status ?? 'todo',
-        progress: data.progress ?? 0,
+        status,
+        progress,
         startDate: data.startDate ?? null,
         dueDate: data.dueDate ?? null,
         updatedAt: new Date(),
@@ -139,4 +145,34 @@ export async function countChildren(parentId: string): Promise<number> {
     .from(tasks)
     .where(eq(tasks.parentId, parentId));
   return children.length;
+}
+
+const STATUS_CYCLE: Record<TaskStatus, TaskStatus> = {
+  todo: 'doing',
+  doing: 'done',
+  done: 'todo',
+};
+
+// 상태 배지 인라인 순환 전환 — 진행률은 건드리지 않는다 (역방향 동기화 금지)
+export async function cycleTaskStatus(id: string): Promise<ActionResult> {
+  if (!UUID_RE.test(id)) return { success: false, error: '작업 ID가 올바르지 않습니다.' };
+  try {
+    const db = getDb();
+    const [row] = await db
+      .select({ status: tasks.status })
+      .from(tasks)
+      .where(eq(tasks.id, id))
+      .limit(1);
+    if (!row) return { success: false, error: '작업을 찾을 수 없습니다.' };
+    const next = STATUS_CYCLE[row.status as TaskStatus] ?? 'todo';
+    await db
+      .update(tasks)
+      .set({ status: next, updatedAt: new Date() })
+      .where(eq(tasks.id, id));
+    revalidatePath('/');
+    return { success: true };
+  } catch (err) {
+    console.error('[cycleTaskStatus] failed', { msg: (err as Error).message });
+    return { success: false, error: '상태 변경에 실패했습니다.' };
+  }
 }

--- a/components/task-row.tsx
+++ b/components/task-row.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Badge, Box, Button, HStack, Table, Text } from '@chakra-ui/react';
+import { Box, Button, HStack, Table, Text } from '@chakra-ui/react';
+import { useTransition } from 'react';
+import { cycleTaskStatus } from '@/app/actions/tasks';
 import type { Task } from '@/lib/types';
 
 const STATUS_CONFIG = {
@@ -30,11 +32,20 @@ export function TaskRow({
   onDelete,
   onAddSubtask,
 }: TaskRowProps) {
+  const [isPending, startTransition] = useTransition();
+
   const statusConfig =
     STATUS_CONFIG[task.status as keyof typeof STATUS_CONFIG] ??
     STATUS_CONFIG.todo;
 
   const toggleIcon = hasChildren ? (isCollapsed ? '▶' : '▼') : null;
+
+  const handleCycleStatus = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    startTransition(async () => {
+      await cycleTaskStatus(task.id);
+    });
+  };
 
   return (
     <Table.Row>
@@ -59,9 +70,15 @@ export function TaskRow({
       </Table.Cell>
       <Table.Cell>{task.assignee ?? '—'}</Table.Cell>
       <Table.Cell>
-        <Badge colorPalette={statusConfig.colorPalette} size="sm">
+        <Button
+          size="xs"
+          variant="subtle"
+          colorPalette={statusConfig.colorPalette}
+          disabled={isPending}
+          onClick={handleCycleStatus}
+        >
           {statusConfig.label}
-        </Badge>
+        </Button>
       </Table.Cell>
       <Table.Cell>{task.progress}%</Table.Cell>
       <Table.Cell>{task.startDate ?? '—'}</Table.Cell>

--- a/lib/tasks/derive-status.ts
+++ b/lib/tasks/derive-status.ts
@@ -1,0 +1,9 @@
+import type { TaskStatus } from '@/lib/types';
+
+export function deriveStatusFromProgress(
+  progress: number,
+  currentStatus: TaskStatus,
+): TaskStatus {
+  if (progress === 100) return 'done';
+  return currentStatus;
+}

--- a/tests/e2e/J5-progress-auto-done.spec.ts
+++ b/tests/e2e/J5-progress-auto-done.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('J5 — 진행률 100% → 상태 자동 "완료"', () => {
+  test('진행률 100 저장 후 상태 배지가 "완료"로 바뀐다', async ({ page }) => {
+    await page.goto('/');
+
+    // 테스트용 작업 생성 (진행률 0, 상태 "할 일")
+    const taskTitle = `J5 테스트 ${Date.now()}`;
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // 방금 만든 행에 "할 일" 배지가 있는지 확인
+    const row = page.getByRole('row').filter({ hasText: taskTitle });
+    await expect(row.getByText('할 일')).toBeVisible();
+
+    // 편집 모달 열기 → 진행률 100 입력 → 저장
+    await row.getByRole('button', { name: '편집' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    const progressInput = page.getByRole('spinbutton');
+    await progressInput.fill('100');
+    await page.getByRole('button', { name: '수정' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // 재렌더 후 상태 배지가 "완료"여야 함
+    await expect(row.getByText('완료')).toBeVisible();
+    await expect(row.getByText('할 일')).not.toBeVisible();
+  });
+});

--- a/tests/e2e/J6-status-cycle.spec.ts
+++ b/tests/e2e/J6-status-cycle.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('J6 — 상태 배지 인라인 순환 전환', () => {
+  test('배지 클릭마다 todo→doing→done→todo 순환하고 진행률은 변하지 않는다', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // 테스트용 작업 생성 (진행률 기본 0)
+    const taskTitle = `J6 테스트 ${Date.now()}`;
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    const row = page.getByRole('row').filter({ hasText: taskTitle });
+
+    // 초기 상태 확인
+    await expect(row.getByText('할 일')).toBeVisible();
+
+    // 초기 진행률 텍스트 캡처 (역방향 동기화 없음 검증용)
+    const progressText = await row.getByText(/^\d+%$/).textContent();
+
+    // 1회 클릭 → 진행 중
+    await row.getByRole('button', { name: '할 일' }).click();
+    await expect(row.getByText('진행 중')).toBeVisible();
+
+    // 2회 클릭 → 완료
+    await row.getByRole('button', { name: '진행 중' }).click();
+    await expect(row.getByText('완료')).toBeVisible();
+
+    // 3회 클릭 → 할 일 (순환)
+    await row.getByRole('button', { name: '완료' }).click();
+    await expect(row.getByText('할 일')).toBeVisible();
+
+    // 진행률은 그대로 — 역방향 동기화 없음
+    await expect(row.getByText(progressText!)).toBeVisible();
+
+    // 새로고침 후에도 마지막 상태("할 일") 유지
+    await page.reload();
+    const rowAfterReload = page.getByRole('row').filter({ hasText: taskTitle });
+    await expect(rowAfterReload.getByText('할 일')).toBeVisible();
+  });
+});

--- a/tests/unit/derive-status.test.ts
+++ b/tests/unit/derive-status.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { deriveStatusFromProgress } from '@/lib/tasks/derive-status';
+
+describe('deriveStatusFromProgress', () => {
+  it('100 미만이면 현재 상태 유지 (todo)', () => {
+    expect(deriveStatusFromProgress(99, 'todo')).toBe('todo');
+  });
+
+  it('100 미만이면 현재 상태 유지 (doing)', () => {
+    expect(deriveStatusFromProgress(99, 'doing')).toBe('doing');
+  });
+
+  it('100 이면 done 으로 강제', () => {
+    expect(deriveStatusFromProgress(100, 'todo')).toBe('done');
+  });
+
+  it('100 이면 done 으로 강제 (doing)', () => {
+    expect(deriveStatusFromProgress(100, 'doing')).toBe('done');
+  });
+
+  it('이미 done 이고 100 이면 done 유지 (멱등)', () => {
+    expect(deriveStatusFromProgress(100, 'done')).toBe('done');
+  });
+
+  it('0 이어도 done 은 유지 — 역방향 동기화 없음', () => {
+    expect(deriveStatusFromProgress(0, 'done')).toBe('done');
+  });
+
+  it('80 이어도 done 은 유지 — 역방향 동기화 없음', () => {
+    expect(deriveStatusFromProgress(80, 'done')).toBe('done');
+  });
+});


### PR DESCRIPTION
Closes #5

## Summary
- SPEC.md §C-2의 두 편집 규칙을 구현: 상태 배지 인라인 클릭 순환(`todo→doing→done→todo`) + 진행률 100 저장 시 상태 자동 `done` 강제
- `deriveStatusFromProgress(progress, currentStatus)` 순수 함수를 서버 액션에 연결해 **역방향 동기화 없음** 규약을 타입 레벨에서 보장
- 기존 정적 Badge를 `useTransition` 기반 클릭형 Button으로 교체 — 모달 없이 `cycleTaskStatus` Server Action 호출

## TDD 증적
- `test: #5 deriveStatusFromProgress 단위 (RED)` → 모듈 미존재로 실패 (7케이스)
- `test: #5 J5·J6 e2e (RED)` → 배지 클릭 핸들러 없음 / updateTask에 derive 미연결로 실패
- `feat: #5 deriveStatusFromProgress + cycleTaskStatus + 클릭형 상태 배지` → GREEN

## Test plan
- [x] `npm run lint` 로컬 초록불
- [x] `npm test` 로컬 초록불 (30 passed)
- [x] `npm run build` 로컬 초록불
- [x] CI `lint-unit-build` 초록불 (1m15s, run #24979913315)
- [x] CI `e2e` 초록불 (2m30s, run #24979913315)

## 파일 변경 요약
| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `lib/tasks/derive-status.ts` | 신규 | 순수 함수 — progress 100이면 done 강제, 역방향 없음 |
| 2 | `app/actions/tasks.ts` | 수정 | updateTask/createTask에 derive 적용, cycleTaskStatus 추가 |
| 3 | `components/task-row.tsx` | 수정 | 정적 Badge → 클릭형 Button (useTransition + stopPropagation) |
| 4 | `tests/unit/derive-status.test.ts` | 신규 | 7케이스 RED→GREEN |
| 5 | `tests/e2e/J5-progress-auto-done.spec.ts` | 신규 | J5 시나리오 |
| 6 | `tests/e2e/J6-status-cycle.spec.ts` | 신규 | J6 시나리오 (진행률 미변동 단언 포함) |

## 관련 시나리오 (USER_JOURNEY.md)
- **J5** 진행률 100% → 상태 자동 "완료" (저장 후 재렌더에서 확인)
- **J6** 상태 배지 인라인 순환 전환 + 새로고침 후 유지 + 진행률 자동 미변동

## 주의
- SPEC.md §C-2 역방향 동기화 금지: cycleTaskStatus는 progress 컬럼을 건드리지 않음. J6 e2e의 "처음 진행률과 동일" 단언이 안전망 역할.
- 스키마 변경 없음 — 마이그레이션 불필요.

Generated with Claude Code

