### PR TITLE
feat: #7 간트형 일정 시각화 뷰 (Claude Design 토큰 + Gantt 보드)

### DIFF
--- a/app/gantt/page.tsx
+++ b/app/gantt/page.tsx
@@ -1,22 +1,27 @@
-import { Container, Text } from '@chakra-ui/react';
+import { Container } from '@chakra-ui/react';
 import { asc } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
 import { tasks } from '@/lib/db/schema';
 import { AppHeader } from '@/components/app-header';
+import { GanttBoard } from '@/components/gantt-board';
 import { buildTaskTree } from '@/lib/tree/build-task-tree';
 
 export const dynamic = 'force-dynamic';
 
+function todayIsoSeoul(): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Seoul' }).format(new Date());
+}
+
 export default async function GanttPage() {
   const db = getDb();
   const allTasks = await db.select().from(tasks).orderBy(asc(tasks.createdAt));
-  void buildTaskTree(allTasks);
+  const tree = buildTaskTree(allTasks);
 
   return (
     <>
       <AppHeader />
       <Container maxW="6xl" py={8}>
-        <Text color="gray.500">간트 보드는 다음 슬라이스에서 추가됩니다.</Text>
+        <GanttBoard nodes={tree} todayIso={todayIsoSeoul()} />
       </Container>
     </>
   );

--- a/app/gantt/page.tsx
+++ b/app/gantt/page.tsx
@@ -5,12 +5,9 @@ import { tasks } from '@/lib/db/schema';
 import { AppHeader } from '@/components/app-header';
 import { GanttBoard } from '@/components/gantt-board';
 import { buildTaskTree } from '@/lib/tree/build-task-tree';
+import { getTodayIso } from '@/lib/dates/today-iso';
 
 export const dynamic = 'force-dynamic';
-
-function todayIsoSeoul(): string {
-  return new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Seoul' }).format(new Date());
-}
 
 export default async function GanttPage() {
   const db = getDb();
@@ -21,7 +18,7 @@ export default async function GanttPage() {
     <>
       <AppHeader />
       <Container maxW="6xl" py={8}>
-        <GanttBoard nodes={tree} todayIso={todayIsoSeoul()} />
+        <GanttBoard nodes={tree} todayIso={getTodayIso()} />
       </Container>
     </>
   );

--- a/app/gantt/page.tsx
+++ b/app/gantt/page.tsx
@@ -1,23 +1,22 @@
-import { Container } from '@chakra-ui/react';
+import { Container, Text } from '@chakra-ui/react';
 import { asc } from 'drizzle-orm';
 import { getDb } from '@/lib/db';
 import { tasks } from '@/lib/db/schema';
-import { TaskList } from '@/components/task-list';
 import { AppHeader } from '@/components/app-header';
 import { buildTaskTree } from '@/lib/tree/build-task-tree';
 
 export const dynamic = 'force-dynamic';
 
-export default async function HomePage() {
+export default async function GanttPage() {
   const db = getDb();
   const allTasks = await db.select().from(tasks).orderBy(asc(tasks.createdAt));
-  const tree = buildTaskTree(allTasks);
+  void buildTaskTree(allTasks);
 
   return (
     <>
       <AppHeader />
-      <Container maxW="5xl" py={8}>
-        <TaskList nodes={tree} />
+      <Container maxW="6xl" py={8}>
+        <Text color="gray.500">간트 보드는 다음 슬라이스에서 추가됩니다.</Text>
       </Container>
     </>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,339 @@
+/*
+ * 디자인 토큰과 헤더/간트 클래스. Claude Design 핸드오프 번들의 styles.css에서
+ * 본 PR(#7) 범위에 해당하는 부분만 이식. List 뷰 시각·Stats strip·Toast·
+ * 모달 시각은 별도 후속 이슈(#27, #28, #29)로 분리. 간트 막대의 overdue 룰
+ * (.gantt-bar.overdue)은 이슈 #11이 추가하므로 본 파일에 포함하지 않는다.
+ */
+
+:root {
+  --bg: #fafafa;
+  --surface: #ffffff;
+  --surface-2: #f5f5f4;
+  --border: #e7e5e4;
+  --border-2: #d6d3d1;
+  --text: #1c1917;
+  --text-muted: #78716c;
+  --text-faint: #a8a29e;
+
+  --accent: oklch(58% 0.18 264);
+  --accent-soft: oklch(96% 0.02 264);
+  --accent-border: oklch(85% 0.06 264);
+
+  --status-todo-bg: #f5f5f4;
+  --status-todo-fg: #57534e;
+  --status-todo-border: #e7e5e4;
+  --status-doing-bg: oklch(96% 0.04 250);
+  --status-doing-fg: oklch(45% 0.14 250);
+  --status-doing-border: oklch(88% 0.05 250);
+  --status-done-bg: oklch(96% 0.05 150);
+  --status-done-fg: oklch(40% 0.13 150);
+  --status-done-border: oklch(85% 0.07 150);
+
+  --danger: oklch(55% 0.21 27);
+  --danger-bg: oklch(96% 0.03 27);
+  --danger-border: oklch(85% 0.08 27);
+
+  --progress-fill: var(--accent);
+  --progress-track: oklch(92% 0.02 264);
+
+  --shadow-sm: 0 1px 2px rgba(28, 25, 23, 0.04);
+  --shadow: 0 1px 3px rgba(28, 25, 23, 0.06), 0 8px 24px -8px rgba(28, 25, 23, 0.08);
+  --shadow-lg: 0 8px 24px -4px rgba(28, 25, 23, 0.12), 0 24px 64px -16px rgba(28, 25, 23, 0.16);
+
+  --font-sans: var(--font-inter), ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, 'SF Mono', Menlo, monospace;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* App header */
+.app-header {
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.app-header-inner {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 14px 28px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+  row-gap: 10px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.brand-mark {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  background: var(--text);
+  color: var(--surface);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+.brand-name {
+  font-size: 15px;
+}
+.brand-sub {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  margin-left: 4px;
+}
+
+.view-toggle {
+  display: inline-flex;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+}
+.view-toggle a {
+  padding: 6px 14px;
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: all 120ms ease;
+  text-decoration: none;
+}
+.view-toggle a.active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: var(--shadow-sm);
+}
+
+.app-spacer {
+  flex: 1;
+}
+
+/* Gantt board (slice 5에서 사용; overdue 룰은 #11) */
+.gantt {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+}
+.gantt-left {
+  border-right: 1px solid var(--border);
+  background: var(--surface);
+}
+.gantt-left-head {
+  height: 56px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  font-weight: 500;
+  padding: 0 16px;
+  display: grid;
+  grid-template-columns: 1fr 60px;
+  align-items: center;
+}
+.gantt-left-spacer {
+  height: 28px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.gantt-row-left {
+  display: grid;
+  grid-template-columns: 1fr 60px;
+  align-items: center;
+  height: 40px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  min-width: 0;
+}
+.gantt-row-left .title-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.gantt-row-left .title-cell .label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gantt-row-left.is-done .label {
+  text-decoration: line-through;
+  color: var(--text-muted);
+}
+.gantt-row-left .pct {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: right;
+}
+.gantt-row-left .pct .empty {
+  color: var(--text-faint);
+  font-style: italic;
+}
+.row-children-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+  background: var(--surface-2);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+.gantt-right {
+  position: relative;
+  overflow-x: auto;
+  min-width: 0;
+}
+.gantt-month-row {
+  display: flex;
+  height: 28px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+.gantt-month {
+  border-right: 1px solid var(--border);
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+  color: var(--text);
+  background: var(--surface-2);
+  font-family: var(--font-mono);
+}
+.gantt-week-row {
+  display: grid;
+  grid-template-columns: repeat(var(--week-count), var(--week-w));
+  height: 28px;
+}
+.gantt-week {
+  border-right: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.gantt-week.is-current {
+  color: var(--accent);
+  font-weight: 500;
+}
+.gantt-body {
+  position: relative;
+}
+.gantt-grid-row {
+  display: grid;
+  grid-template-columns: repeat(var(--week-count), var(--week-w));
+  height: 40px;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+.gantt-grid-cell {
+  border-right: 1px solid var(--border);
+}
+.gantt-grid-cell.is-current-week {
+  background: rgba(0, 0, 0, 0.012);
+}
+.gantt-today {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: 1.5px solid var(--accent);
+  z-index: 5;
+  pointer-events: none;
+}
+.gantt-today::after {
+  content: '오늘';
+  position: absolute;
+  top: -22px;
+  left: -16px;
+  background: var(--accent);
+  color: white;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.gantt-bar {
+  position: absolute;
+  top: 8px;
+  height: 24px;
+  border-radius: 5px;
+  overflow: hidden;
+  background: var(--progress-track);
+  display: flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text);
+}
+.gantt-bar-fill {
+  height: 100%;
+  background: var(--progress-fill);
+  transition: width 240ms ease;
+}
+.gantt-bar.is-done .gantt-bar-fill {
+  background: var(--status-done-fg);
+}
+.gantt-bar-label {
+  position: absolute;
+  top: 50%;
+  left: 8px;
+  transform: translateY(-50%);
+  white-space: nowrap;
+  pointer-events: none;
+  font-size: 11px;
+  color: var(--text);
+  text-shadow: 0 0 4px var(--surface);
+}
+.gantt-empty-bar {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+  font-style: italic;
+  background: repeating-linear-gradient(
+    -45deg,
+    transparent 0,
+    transparent 6px,
+    var(--surface-2) 6px,
+    var(--surface-2) 12px
+  );
+  border: 1px dashed var(--border-2);
+  border-radius: 5px;
+  padding: 4px 12px;
+  white-space: nowrap;
+  pointer-events: none;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,22 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { Inter, JetBrains_Mono } from 'next/font/google';
 import { Providers } from './providers';
+import './globals.css';
+
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-inter',
+  display: 'swap',
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  variable: '--font-jetbrains-mono',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: 'WBS',
@@ -9,7 +25,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="ko" suppressHydrationWarning>
+    <html lang="ko" className={`${inter.variable} ${jetbrainsMono.variable}`} suppressHydrationWarning>
       <body>
         <Providers>{children}</Providers>
       </body>

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -6,7 +6,7 @@ export function AppHeader() {
       <div className="app-header-inner">
         <div className="brand">
           <div className="brand-mark">W</div>
-          <div className="brand-name">WBS</div>
+          <h1 className="brand-name">WBS</h1>
           <div className="brand-sub">v0.1 · MVP</div>
         </div>
         <ViewToggle />

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -1,0 +1,17 @@
+import { ViewToggle } from './view-toggle';
+
+export function AppHeader() {
+  return (
+    <header className="app-header">
+      <div className="app-header-inner">
+        <div className="brand">
+          <div className="brand-mark">W</div>
+          <div className="brand-name">WBS</div>
+          <div className="brand-sub">v0.1 · MVP</div>
+        </div>
+        <ViewToggle />
+        <div className="app-spacer" />
+      </div>
+    </header>
+  );
+}

--- a/components/gantt-board.tsx
+++ b/components/gantt-board.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { CSSProperties } from 'react';
+import type { TaskNode } from '@/lib/tree/build-task-tree';
+import { computeGridRange, todayOffsetDays } from '@/lib/gantt/grid-range';
+import { computeBarStyle } from '@/lib/gantt/compute-bar-style';
+
+const WEEK_WIDTH_PX = 96;
+const DAY_WIDTH_PX = WEEK_WIDTH_PX / 7;
+
+interface GanttBoardProps {
+  nodes: TaskNode[];
+  todayIso: string;
+}
+
+function parseIsoDate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function isSameWeek(d: Date, weekStart: Date): boolean {
+  const weekEnd = new Date(weekStart.getTime());
+  weekEnd.setUTCDate(weekEnd.getUTCDate() + 7);
+  return d.getTime() >= weekStart.getTime() && d.getTime() < weekEnd.getTime();
+}
+
+export function GanttBoard({ nodes, todayIso }: GanttBoardProps) {
+  const today = useMemo(() => parseIsoDate(todayIso), [todayIso]);
+  const tasksForRange = useMemo(
+    () => nodes.map((n) => ({ startDate: n.task.startDate, dueDate: n.task.dueDate })),
+    [nodes]
+  );
+  const range = useMemo(() => computeGridRange(tasksForRange, today), [tasksForRange, today]);
+
+  const childCounts = useMemo(() => {
+    const m: Record<string, number> = {};
+    for (const n of nodes) {
+      const pid = n.task.parentId;
+      if (pid) m[pid] = (m[pid] ?? 0) + 1;
+    }
+    return m;
+  }, [nodes]);
+
+  const todayLeftPx = todayOffsetDays(range.start, today) * DAY_WIDTH_PX;
+  const todayInRange = today.getTime() >= range.start.getTime() && today.getTime() < range.end.getTime();
+
+  const cssVars = {
+    '--week-count': range.weeks.length,
+    '--week-w': `${WEEK_WIDTH_PX}px`,
+  } as CSSProperties;
+
+  if (!nodes.length) {
+    return (
+      <div style={{ padding: '40px 16px', color: 'var(--text-muted)', textAlign: 'center' }}>
+        간트 뷰가 비어 있습니다. 목록 뷰에서 작업을 추가하세요.
+      </div>
+    );
+  }
+
+  return (
+    <div className="gantt" style={cssVars}>
+      <div className="gantt-left">
+        <div className="gantt-left-head">
+          <div>작업</div>
+          <div style={{ textAlign: 'right' }}>진행률</div>
+        </div>
+        <div className="gantt-left-spacer" />
+        {nodes.map((n) => {
+          const isDone = n.task.status === 'done';
+          const hasDates = !!(n.task.startDate && n.task.dueDate);
+          return (
+            <div key={n.task.id} className={`gantt-row-left ${isDone ? 'is-done' : ''}`}>
+              <div className="title-cell" style={{ paddingLeft: n.depth * 16 }}>
+                <span className="label">{n.task.title}</span>
+                {n.hasChildren && (
+                  <span className="row-children-count">{childCounts[n.task.id] ?? 0}</span>
+                )}
+              </div>
+              <div className="pct">
+                {hasDates ? `${n.task.progress}%` : <span className="empty">미정</span>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="gantt-right">
+        <div style={{ minWidth: '100%' }}>
+          <div className="gantt-month-row">
+            {range.months.map((m) => (
+              <div key={m.key} className="gantt-month" style={{ width: m.weeks * WEEK_WIDTH_PX }}>
+                {m.label}
+              </div>
+            ))}
+          </div>
+          <div className="gantt-week-row">
+            {range.weeks.map((w, i) => (
+              <div
+                key={i}
+                className={`gantt-week ${isSameWeek(today, w) ? 'is-current' : ''}`}
+              >
+                {w.getUTCMonth() + 1}/{w.getUTCDate()}
+              </div>
+            ))}
+          </div>
+          <div className="gantt-body">
+            {todayInRange && <div className="gantt-today" style={{ left: todayLeftPx }} />}
+            {nodes.map((n) => {
+              const bar = computeBarStyle(
+                { rangeStart: range.rangeStartIso, dayWidth: DAY_WIDTH_PX },
+                { startDate: n.task.startDate, dueDate: n.task.dueDate }
+              );
+              const isDone = n.task.status === 'done';
+              return (
+                <div className="gantt-grid-row" key={n.task.id}>
+                  {range.weeks.map((w, i) => (
+                    <div
+                      key={i}
+                      className={`gantt-grid-cell ${isSameWeek(today, w) ? 'is-current-week' : ''}`}
+                    />
+                  ))}
+                  {bar ? (
+                    <div
+                      className={`gantt-bar ${isDone ? 'is-done' : ''}`}
+                      style={{ left: bar.leftPx, width: bar.widthPx }}
+                    >
+                      <div className="gantt-bar-fill" style={{ width: `${n.task.progress}%` }} />
+                      <span className="gantt-bar-label">{n.task.progress}%</span>
+                    </div>
+                  ) : (
+                    <div className="gantt-empty-bar">— 일정 없음 —</div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/view-toggle.tsx
+++ b/components/view-toggle.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export function ViewToggle() {
+  const pathname = usePathname();
+  const isList = pathname === '/';
+  const isGantt = pathname.startsWith('/gantt');
+  return (
+    <nav className="view-toggle" aria-label="뷰 전환">
+      <Link href="/" className={isList ? 'active' : undefined}>
+        목록
+      </Link>
+      <Link href="/gantt" className={isGantt ? 'active' : undefined}>
+        간트
+      </Link>
+    </nav>
+  );
+}

--- a/components/view-toggle.tsx
+++ b/components/view-toggle.tsx
@@ -6,13 +6,21 @@ import { usePathname } from 'next/navigation';
 export function ViewToggle() {
   const pathname = usePathname();
   const isList = pathname === '/';
-  const isGantt = pathname.startsWith('/gantt');
+  const isGantt = pathname === '/gantt' || pathname.startsWith('/gantt/');
   return (
     <nav className="view-toggle" aria-label="뷰 전환">
-      <Link href="/" className={isList ? 'active' : undefined}>
+      <Link
+        href="/"
+        className={isList ? 'active' : undefined}
+        aria-current={isList ? 'page' : undefined}
+      >
         목록
       </Link>
-      <Link href="/gantt" className={isGantt ? 'active' : undefined}>
+      <Link
+        href="/gantt"
+        className={isGantt ? 'active' : undefined}
+        aria-current={isGantt ? 'page' : undefined}
+      >
         간트
       </Link>
     </nav>

--- a/lib/dates/today-iso.ts
+++ b/lib/dates/today-iso.ts
@@ -1,0 +1,14 @@
+/**
+ * 앱 기준 타임존. 현재 MVP는 단일 사용자 가정이므로 한국 시각 자정을
+ * "오늘"의 경계로 본다. 다중 사용자 도입 시 사용자 prefs로 옮긴다.
+ */
+export const APP_TZ = 'Asia/Seoul';
+
+/**
+ * APP_TZ 기준 오늘 날짜를 'YYYY-MM-DD' 문자열로 돌려준다.
+ * Server Component에서 한 번 산출해 Client Component prop으로 내려보내는 용도.
+ * (`new Intl.DateTimeFormat('en-CA', ...)`는 'YYYY-MM-DD' 포맷을 보장한다.)
+ */
+export function getTodayIso(now: Date = new Date()): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: APP_TZ }).format(now);
+}

--- a/lib/gantt/compute-bar-style.ts
+++ b/lib/gantt/compute-bar-style.ts
@@ -1,0 +1,38 @@
+export type BarRange = {
+  rangeStart: string;
+  dayWidth: number;
+};
+
+export type BarTask = {
+  startDate: string | null;
+  dueDate: string | null;
+};
+
+export type BarStyle = {
+  leftPx: number;
+  widthPx: number;
+};
+
+const MS_PER_DAY = 86400000;
+const MIN_BAR_WIDTH_PX = 12;
+const BAR_GAP_PX = 2;
+
+function parseIsoDate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.round((b.getTime() - a.getTime()) / MS_PER_DAY);
+}
+
+export function computeBarStyle(range: BarRange, task: BarTask): BarStyle | null {
+  if (!task.startDate || !task.dueDate) return null;
+  const rangeStart = parseIsoDate(range.rangeStart);
+  const start = parseIsoDate(task.startDate);
+  const end = parseIsoDate(task.dueDate);
+  const leftPx = daysBetween(rangeStart, start) * range.dayWidth;
+  const inclusiveDays = daysBetween(start, end) + 1;
+  const widthPx = Math.max(inclusiveDays * range.dayWidth - BAR_GAP_PX, MIN_BAR_WIDTH_PX);
+  return { leftPx, widthPx };
+}

--- a/lib/gantt/grid-range.ts
+++ b/lib/gantt/grid-range.ts
@@ -1,0 +1,105 @@
+export type GridMonth = {
+  key: string;
+  label: string;
+  weeks: number;
+};
+
+export type GridRange = {
+  start: Date;
+  end: Date;
+  weeks: Date[];
+  months: GridMonth[];
+  totalDays: number;
+  rangeStartIso: string;
+};
+
+const MS_PER_DAY = 86400000;
+
+function parseIsoDate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function toIsoDate(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function startOfWeekUTC(d: Date): Date {
+  const result = new Date(d.getTime());
+  const dow = result.getUTCDay();
+  result.setUTCDate(result.getUTCDate() - dow);
+  result.setUTCHours(0, 0, 0, 0);
+  return result;
+}
+
+function todayUTC(today: Date): Date {
+  return new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+}
+
+export function computeGridRange(
+  tasks: { startDate: string | null; dueDate: string | null }[],
+  today: Date
+): GridRange {
+  const dates: Date[] = [];
+  for (const t of tasks) {
+    if (t.startDate) dates.push(parseIsoDate(t.startDate));
+    if (t.dueDate) dates.push(parseIsoDate(t.dueDate));
+  }
+  const todayMidnight = todayUTC(today);
+
+  let start: Date;
+  let end: Date;
+
+  if (dates.length === 0) {
+    const a = new Date(todayMidnight.getTime());
+    a.setUTCDate(a.getUTCDate() - 14);
+    const b = new Date(todayMidnight.getTime());
+    b.setUTCDate(b.getUTCDate() + 28);
+    start = startOfWeekUTC(a);
+    end = startOfWeekUTC(b);
+  } else {
+    dates.push(todayMidnight);
+    let min = dates[0];
+    let max = dates[0];
+    for (const d of dates) {
+      if (d.getTime() < min.getTime()) min = d;
+      if (d.getTime() > max.getTime()) max = d;
+    }
+    start = startOfWeekUTC(min);
+    start.setUTCDate(start.getUTCDate() - 7);
+    end = startOfWeekUTC(max);
+    end.setUTCDate(end.getUTCDate() + 14);
+  }
+
+  const weeks: Date[] = [];
+  for (
+    let d = new Date(start.getTime());
+    d.getTime() < end.getTime();
+    d.setUTCDate(d.getUTCDate() + 7)
+  ) {
+    weeks.push(new Date(d.getTime()));
+  }
+
+  const months: GridMonth[] = [];
+  for (const w of weeks) {
+    const key = `${w.getUTCFullYear()}-${w.getUTCMonth()}`;
+    const last = months[months.length - 1];
+    if (!last || last.key !== key) {
+      months.push({ key, label: `${w.getUTCFullYear()}년 ${w.getUTCMonth() + 1}월`, weeks: 1 });
+    } else {
+      last.weeks += 1;
+    }
+  }
+
+  const totalDays = Math.round((end.getTime() - start.getTime()) / MS_PER_DAY);
+
+  return { start, end, weeks, months, totalDays, rangeStartIso: toIsoDate(start) };
+}
+
+export function todayOffsetDays(rangeStart: Date, today: Date): number {
+  const t = todayUTC(today);
+  return Math.round((t.getTime() - rangeStart.getTime()) / MS_PER_DAY);
+}

--- a/tests/e2e/J13-gantt-toggle.spec.ts
+++ b/tests/e2e/J13-gantt-toggle.spec.ts
@@ -30,6 +30,16 @@ test.describe('J13 — 간트 뷰로 전환', () => {
     await page.getByRole('link', { name: '간트' }).click();
     await expect(page).toHaveURL(/\/gantt$/);
 
+    // 토글 active 상태가 'aria-current=page' 로 노출됨 (a11y 계약)
+    await expect(page.getByRole('link', { name: '간트' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    await expect(page.getByRole('link', { name: '목록' })).not.toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+
     // 좌측 트리: 두 작업의 제목이 좌측 영역에 보임
     await expect(page.getByText(tsScheduled)).toBeVisible();
     await expect(page.getByText(tsNoDates)).toBeVisible();

--- a/tests/e2e/J13-gantt-toggle.spec.ts
+++ b/tests/e2e/J13-gantt-toggle.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { waitForDialogClosed } from './_helpers/dialog';
+import { isoDateOffset } from './_helpers/dates';
 
 test.describe('J13 — 간트 뷰로 전환', () => {
   test('토글에서 "간트" 클릭 시 /gantt 라우트, 좌측 트리·우측 그리드·오늘 강조선·"일정 없음" 표기', async ({
@@ -7,12 +8,12 @@ test.describe('J13 — 간트 뷰로 전환', () => {
   }) => {
     await page.goto('/');
 
-    // 시작일/기한 모두 있는 작업
+    // 시작일/기한 모두 있는 작업 (오늘 +6d ~ +10d — `computeGridRange` 윈도우 안)
     const tsScheduled = `J13 일정있음 ${Date.now()}`;
     await page.getByRole('button', { name: '+ 작업 추가' }).click();
     await page.getByPlaceholder('작업 제목').fill(tsScheduled);
-    await page.locator('input[type="date"]').nth(0).fill('2026-05-04');
-    await page.locator('input[type="date"]').nth(1).fill('2026-05-08');
+    await page.locator('input[type="date"]').nth(0).fill(isoDateOffset(6));
+    await page.locator('input[type="date"]').nth(1).fill(isoDateOffset(10));
     await page.getByRole('button', { name: '추가' }).click();
     await waitForDialogClosed(page);
     await expect(page.getByText(tsScheduled)).toBeVisible();

--- a/tests/e2e/J13-gantt-toggle.spec.ts
+++ b/tests/e2e/J13-gantt-toggle.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { waitForDialogClosed } from './_helpers/dialog';
 
 test.describe('J13 — 간트 뷰로 전환', () => {
   test('토글에서 "간트" 클릭 시 /gantt 라우트, 좌측 트리·우측 그리드·오늘 강조선·"일정 없음" 표기', async ({
@@ -10,17 +11,19 @@ test.describe('J13 — 간트 뷰로 전환', () => {
     const tsScheduled = `J13 일정있음 ${Date.now()}`;
     await page.getByRole('button', { name: '+ 작업 추가' }).click();
     await page.getByPlaceholder('작업 제목').fill(tsScheduled);
-    await page.getByLabel('시작일').fill('2026-05-04');
-    await page.getByLabel('목표 기한').fill('2026-05-08');
+    await page.locator('input[type="date"]').nth(0).fill('2026-05-04');
+    await page.locator('input[type="date"]').nth(1).fill('2026-05-08');
     await page.getByRole('button', { name: '추가' }).click();
-    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await waitForDialogClosed(page);
+    await expect(page.getByText(tsScheduled)).toBeVisible();
 
     // 일정 없는 작업
     const tsNoDates = `J13 일정없음 ${Date.now() + 1}`;
     await page.getByRole('button', { name: '+ 작업 추가' }).click();
     await page.getByPlaceholder('작업 제목').fill(tsNoDates);
     await page.getByRole('button', { name: '추가' }).click();
-    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await waitForDialogClosed(page);
+    await expect(page.getByText(tsNoDates)).toBeVisible();
 
     // 토글 → 간트
     await page.getByRole('link', { name: '간트' }).click();

--- a/tests/e2e/J13-gantt-toggle.spec.ts
+++ b/tests/e2e/J13-gantt-toggle.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('J13 — 간트 뷰로 전환', () => {
+  test('토글에서 "간트" 클릭 시 /gantt 라우트, 좌측 트리·우측 그리드·오늘 강조선·"일정 없음" 표기', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // 시작일/기한 모두 있는 작업
+    const tsScheduled = `J13 일정있음 ${Date.now()}`;
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await page.getByPlaceholder('작업 제목').fill(tsScheduled);
+    await page.getByLabel('시작일').fill('2026-05-04');
+    await page.getByLabel('목표 기한').fill('2026-05-08');
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // 일정 없는 작업
+    const tsNoDates = `J13 일정없음 ${Date.now() + 1}`;
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await page.getByPlaceholder('작업 제목').fill(tsNoDates);
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // 토글 → 간트
+    await page.getByRole('link', { name: '간트' }).click();
+    await expect(page).toHaveURL(/\/gantt$/);
+
+    // 좌측 트리: 두 작업의 제목이 좌측 영역에 보임
+    await expect(page.getByText(tsScheduled)).toBeVisible();
+    await expect(page.getByText(tsNoDates)).toBeVisible();
+
+    // 우측 그리드 + 오늘 세로선
+    await expect(page.locator('.gantt-today')).toHaveCount(1);
+
+    // 일정 있는 작업 행에 막대 1개 이상
+    await expect(page.locator('.gantt-bar').first()).toBeVisible();
+
+    // 일정 없는 작업 행에 "일정 없음" 표기
+    await expect(page.locator('.gantt-empty-bar', { hasText: '일정 없음' }).first()).toBeVisible();
+  });
+});

--- a/tests/e2e/J14-gantt-progress-fill.spec.ts
+++ b/tests/e2e/J14-gantt-progress-fill.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { waitForDialogClosed } from './_helpers/dialog';
 
 test.describe('J14 — 간트 막대의 진행률 채움', () => {
   test('진행률 60% → 막대 fill width: 60%, 30%로 변경 후 재진입 시 30%', async ({
@@ -9,19 +10,24 @@ test.describe('J14 — 간트 막대의 진행률 채움', () => {
     const taskTitle = `J14 진행률 ${Date.now()}`;
     await page.getByRole('button', { name: '+ 작업 추가' }).click();
     await page.getByPlaceholder('작업 제목').fill(taskTitle);
-    await page.getByLabel('시작일').fill('2026-05-01');
-    await page.getByLabel('목표 기한').fill('2026-05-10');
+    await page.locator('input[type="date"]').nth(0).fill('2026-05-01');
+    await page.locator('input[type="date"]').nth(1).fill('2026-05-10');
     await page.getByRole('spinbutton').first().fill('60');
     await page.getByRole('button', { name: '추가' }).click();
-    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await waitForDialogClosed(page);
+    await expect(page.getByText(taskTitle)).toBeVisible();
 
     // 간트 진입
     await page.getByRole('link', { name: '간트' }).click();
     await expect(page).toHaveURL(/\/gantt$/);
 
-    // 해당 작업 행의 fill width: 60%
-    const row = page.locator('.gantt-grid-row').filter({ has: page.locator('.gantt-bar') }).first();
-    const fill = row.locator('.gantt-bar-fill');
+    // 해당 작업 행의 fill width: 60% (제목으로 좌측 행 인덱스 찾고 같은 인덱스의 우측 행 검사)
+    const idx = await page.evaluate((t) => {
+      const rows = Array.from(document.querySelectorAll('.gantt-row-left'));
+      return rows.findIndex((r) => (r.textContent ?? '').includes(t));
+    }, taskTitle);
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const fill = page.locator('.gantt-grid-row').nth(idx).locator('.gantt-bar-fill');
     await expect(fill).toBeVisible();
     await expect(fill).toHaveAttribute('style', /width:\s*60%/);
 
@@ -32,12 +38,17 @@ test.describe('J14 — 간트 막대의 진행률 채움', () => {
     await taskRow.getByRole('button', { name: '편집' }).click();
     await page.getByRole('spinbutton').first().fill('30');
     await page.getByRole('button', { name: '수정' }).click();
-    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await waitForDialogClosed(page);
 
     // 간트 재진입 → fill width: 30%
     await page.getByRole('link', { name: '간트' }).click();
     await expect(page).toHaveURL(/\/gantt$/);
-    const fill2 = page.locator('.gantt-bar-fill').first();
+    const idx2 = await page.evaluate((t) => {
+      const rows = Array.from(document.querySelectorAll('.gantt-row-left'));
+      return rows.findIndex((r) => (r.textContent ?? '').includes(t));
+    }, taskTitle);
+    expect(idx2).toBeGreaterThanOrEqual(0);
+    const fill2 = page.locator('.gantt-grid-row').nth(idx2).locator('.gantt-bar-fill');
     await expect(fill2).toHaveAttribute('style', /width:\s*30%/);
   });
 });

--- a/tests/e2e/J14-gantt-progress-fill.spec.ts
+++ b/tests/e2e/J14-gantt-progress-fill.spec.ts
@@ -41,6 +41,11 @@ test.describe('J14 — 간트 막대의 진행률 채움', () => {
     await page.getByRole('button', { name: '수정' }).click();
     await waitForDialogClosed(page);
 
+    // 목록 행의 진행률이 30%로 갱신될 때까지 대기 (DB write + revalidate 보장).
+    // 이 단계 없이 곧장 /gantt 로 이동하면 간헐적으로 60% 직후의 정렬·인덱스를
+    // 잡아 fill 셀렉터가 다른 행을 가리키는 race 가 생긴다.
+    await expect(taskRow).toContainText('30%');
+
     // 간트 재진입 → fill width: 30%
     await page.getByRole('link', { name: '간트' }).click();
     await expect(page).toHaveURL(/\/gantt$/);

--- a/tests/e2e/J14-gantt-progress-fill.spec.ts
+++ b/tests/e2e/J14-gantt-progress-fill.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { waitForDialogClosed } from './_helpers/dialog';
+import { isoDateOffset } from './_helpers/dates';
 
 test.describe('J14 — 간트 막대의 진행률 채움', () => {
   test('진행률 60% → 막대 fill width: 60%, 30%로 변경 후 재진입 시 30%', async ({
@@ -10,8 +11,8 @@ test.describe('J14 — 간트 막대의 진행률 채움', () => {
     const taskTitle = `J14 진행률 ${Date.now()}`;
     await page.getByRole('button', { name: '+ 작업 추가' }).click();
     await page.getByPlaceholder('작업 제목').fill(taskTitle);
-    await page.locator('input[type="date"]').nth(0).fill('2026-05-01');
-    await page.locator('input[type="date"]').nth(1).fill('2026-05-10');
+    await page.locator('input[type="date"]').nth(0).fill(isoDateOffset(3));
+    await page.locator('input[type="date"]').nth(1).fill(isoDateOffset(12));
     await page.getByRole('spinbutton').first().fill('60');
     await page.getByRole('button', { name: '추가' }).click();
     await waitForDialogClosed(page);

--- a/tests/e2e/J14-gantt-progress-fill.spec.ts
+++ b/tests/e2e/J14-gantt-progress-fill.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('J14 — 간트 막대의 진행률 채움', () => {
+  test('진행률 60% → 막대 fill width: 60%, 30%로 변경 후 재진입 시 30%', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    const taskTitle = `J14 진행률 ${Date.now()}`;
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.getByLabel('시작일').fill('2026-05-01');
+    await page.getByLabel('목표 기한').fill('2026-05-10');
+    await page.getByRole('spinbutton').first().fill('60');
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // 간트 진입
+    await page.getByRole('link', { name: '간트' }).click();
+    await expect(page).toHaveURL(/\/gantt$/);
+
+    // 해당 작업 행의 fill width: 60%
+    const row = page.locator('.gantt-grid-row').filter({ has: page.locator('.gantt-bar') }).first();
+    const fill = row.locator('.gantt-bar-fill');
+    await expect(fill).toBeVisible();
+    await expect(fill).toHaveAttribute('style', /width:\s*60%/);
+
+    // 목록 뷰로 돌아가 진행률 30 변경
+    await page.getByRole('link', { name: '목록' }).click();
+    await expect(page).toHaveURL(/\/$/);
+    const taskRow = page.getByRole('row').filter({ hasText: taskTitle });
+    await taskRow.getByRole('button', { name: '편집' }).click();
+    await page.getByRole('spinbutton').first().fill('30');
+    await page.getByRole('button', { name: '수정' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    // 간트 재진입 → fill width: 30%
+    await page.getByRole('link', { name: '간트' }).click();
+    await expect(page).toHaveURL(/\/gantt$/);
+    const fill2 = page.locator('.gantt-bar-fill').first();
+    await expect(fill2).toHaveAttribute('style', /width:\s*30%/);
+  });
+});

--- a/tests/e2e/J16-gantt-readonly.spec.ts
+++ b/tests/e2e/J16-gantt-readonly.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('J16 — 간트는 읽기 전용', () => {
+  test('막대 드래그 시도 후에도 막대 위치/폭이 변하지 않는다', async ({ page }) => {
+    await page.goto('/');
+
+    const taskTitle = `J16 읽기전용 ${Date.now()}`;
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.getByLabel('시작일').fill('2026-05-04');
+    await page.getByLabel('목표 기한').fill('2026-05-08');
+    await page.getByRole('button', { name: '추가' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    await page.getByRole('link', { name: '간트' }).click();
+    await expect(page).toHaveURL(/\/gantt$/);
+
+    const bar = page.locator('.gantt-bar').first();
+    await expect(bar).toBeVisible();
+
+    const before = await bar.boundingBox();
+    expect(before).not.toBeNull();
+
+    // 막대 중앙에서 +120px 가량 우측으로 드래그 시도
+    const cx = before!.x + before!.width / 2;
+    const cy = before!.y + before!.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 120, cy, { steps: 10 });
+    await page.mouse.up();
+
+    // 막대 끝(우측)을 잡아 리사이즈 시도
+    const ex = before!.x + before!.width - 1;
+    const ey = before!.y + before!.height / 2;
+    await page.mouse.move(ex, ey);
+    await page.mouse.down();
+    await page.mouse.move(ex + 80, ey, { steps: 10 });
+    await page.mouse.up();
+
+    const after = await bar.boundingBox();
+    expect(after).not.toBeNull();
+    expect(after!.x).toBeCloseTo(before!.x, 0);
+    expect(after!.width).toBeCloseTo(before!.width, 0);
+  });
+});

--- a/tests/e2e/J16-gantt-readonly.spec.ts
+++ b/tests/e2e/J16-gantt-readonly.spec.ts
@@ -1,15 +1,18 @@
 import { test, expect } from '@playwright/test';
 import { waitForDialogClosed } from './_helpers/dialog';
+import { isoDateOffset } from './_helpers/dates';
 
 test.describe('J16 — 간트는 읽기 전용', () => {
-  test('막대 드래그 시도 후에도 막대 위치/폭이 변하지 않는다', async ({ page }) => {
+  test('막대에 드래그 핸들러가 없고, 드래그/리사이즈 시도 후에도 위치·폭이 그대로다', async ({
+    page,
+  }) => {
     await page.goto('/');
 
     const taskTitle = `J16 읽기전용 ${Date.now()}`;
     await page.getByRole('button', { name: '+ 작업 추가' }).click();
     await page.getByPlaceholder('작업 제목').fill(taskTitle);
-    await page.locator('input[type="date"]').nth(0).fill('2026-05-04');
-    await page.locator('input[type="date"]').nth(1).fill('2026-05-08');
+    await page.locator('input[type="date"]').nth(0).fill(isoDateOffset(6));
+    await page.locator('input[type="date"]').nth(1).fill(isoDateOffset(10));
     await page.getByRole('button', { name: '추가' }).click();
     await waitForDialogClosed(page);
     await expect(page.getByText(taskTitle)).toBeVisible();
@@ -19,6 +22,23 @@ test.describe('J16 — 간트는 읽기 전용', () => {
 
     const bar = page.locator('.gantt-bar').first();
     await expect(bar).toBeVisible();
+
+    // SPEC §9 핵심 계약: 막대에 드래그 관련 핸들러·속성이 일체 없어야 한다.
+    // (boundingBox 동치만 보면 pointer-events:none 같은 CSS 우회로 통과 가능.)
+    await expect(bar).not.toHaveAttribute('draggable', 'true');
+    const handlers = await bar.evaluate((el) => {
+      const e = el as HTMLElement & {
+        onpointerdown: unknown;
+        onmousedown: unknown;
+        ondragstart: unknown;
+      };
+      return {
+        pointerdown: typeof e.onpointerdown === 'function',
+        mousedown: typeof e.onmousedown === 'function',
+        dragstart: typeof e.ondragstart === 'function',
+      };
+    });
+    expect(handlers).toEqual({ pointerdown: false, mousedown: false, dragstart: false });
 
     const before = await bar.boundingBox();
     expect(before).not.toBeNull();

--- a/tests/e2e/J16-gantt-readonly.spec.ts
+++ b/tests/e2e/J16-gantt-readonly.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { waitForDialogClosed } from './_helpers/dialog';
 
 test.describe('J16 — 간트는 읽기 전용', () => {
   test('막대 드래그 시도 후에도 막대 위치/폭이 변하지 않는다', async ({ page }) => {
@@ -7,10 +8,11 @@ test.describe('J16 — 간트는 읽기 전용', () => {
     const taskTitle = `J16 읽기전용 ${Date.now()}`;
     await page.getByRole('button', { name: '+ 작업 추가' }).click();
     await page.getByPlaceholder('작업 제목').fill(taskTitle);
-    await page.getByLabel('시작일').fill('2026-05-04');
-    await page.getByLabel('목표 기한').fill('2026-05-08');
+    await page.locator('input[type="date"]').nth(0).fill('2026-05-04');
+    await page.locator('input[type="date"]').nth(1).fill('2026-05-08');
     await page.getByRole('button', { name: '추가' }).click();
-    await expect(page.getByRole('dialog')).not.toBeVisible();
+    await waitForDialogClosed(page);
+    await expect(page.getByText(taskTitle)).toBeVisible();
 
     await page.getByRole('link', { name: '간트' }).click();
     await expect(page).toHaveURL(/\/gantt$/);

--- a/tests/e2e/_helpers/dates.ts
+++ b/tests/e2e/_helpers/dates.ts
@@ -1,0 +1,13 @@
+/**
+ * UTC 기준 N일 후의 'YYYY-MM-DD' 문자열을 반환한다.
+ *
+ * e2e가 하드코드된 절대 날짜를 쓰면 시간이 흐를수록 `computeGridRange`의
+ * 윈도우(오늘 -14d / +28d) 밖으로 떨어져 `.gantt-bar` 가시성 검증이 깨진다.
+ * 항상 "오늘 기준 +Nd"로 적어 두면 캘린더가 흘러도 윈도우 안에 머문다.
+ */
+export function isoDateOffset(days: number, base: Date = new Date()): string {
+  const d = new Date(
+    Date.UTC(base.getUTCFullYear(), base.getUTCMonth(), base.getUTCDate() + days),
+  );
+  return d.toISOString().slice(0, 10);
+}

--- a/tests/e2e/_helpers/dialog.ts
+++ b/tests/e2e/_helpers/dialog.ts
@@ -1,0 +1,24 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Chakra v3 Dialog (Zag.js)는 닫힐 때 body 의 scroll-lock 인라인 스타일
+ * (overflow: hidden; pointer-events: none;) 과 일부 ancestor의 aria-hidden=true
+ * 를 깨끗이 정리하지 못하는 경우가 있다(특히 unmountOnExit 사용 시).
+ * 그 결과 dialog 가 사라진 직후 outside-area 클릭/접근성 쿼리가 막힌다.
+ *
+ * 해당 lifecycle 버그는 본 이슈(#7) 범위 밖이며 별도로 트래킹한다. 신규 e2e
+ * 테스트가 안정적으로 돌도록, dialog 가 분리된 직후 잔재 스타일/속성을 강제로
+ * 청소한다.
+ */
+export async function waitForDialogClosed(page: Page) {
+  await expect(page.locator('[role="dialog"]')).toHaveCount(0);
+  await page.evaluate(() => {
+    document.body.style.removeProperty('overflow');
+    document.body.style.removeProperty('pointer-events');
+    document.querySelectorAll('[aria-hidden="true"]').forEach((el) => {
+      if (!el.closest('[role="dialog"], [role="alertdialog"]')) {
+        el.removeAttribute('aria-hidden');
+      }
+    });
+  });
+}

--- a/tests/e2e/_helpers/dialog.ts
+++ b/tests/e2e/_helpers/dialog.ts
@@ -2,21 +2,24 @@ import { expect, type Page } from '@playwright/test';
 
 /**
  * Chakra v3 Dialog (Zag.js)는 닫힐 때 body 의 scroll-lock 인라인 스타일
- * (overflow: hidden; pointer-events: none;) 과 일부 ancestor의 aria-hidden=true
- * 를 깨끗이 정리하지 못하는 경우가 있다(특히 unmountOnExit 사용 시).
- * 그 결과 dialog 가 사라진 직후 outside-area 클릭/접근성 쿼리가 막힌다.
+ * (overflow: hidden; pointer-events: none;) 과 body 직속 형제 노드의
+ * aria-hidden=true 를 깨끗이 정리하지 못하는 경우가 있다.
  *
- * 해당 lifecycle 버그는 본 이슈(#7) 범위 밖이며 별도로 트래킹한다. 신규 e2e
- * 테스트가 안정적으로 돌도록, dialog 가 분리된 직후 잔재 스타일/속성을 강제로
- * 청소한다.
+ * TODO(#30): Chakra Dialog scroll-lock 잔재가 lifecycle 측에서 해결되면
+ * 본 헬퍼는 단순 `expect(...).toHaveCount(0)` 으로 단순화 후 삭제한다.
+ * (이슈 #30 수용 기준 3 참고.)
+ *
+ * aria-hidden 제거 범위는 의도적으로 body 직속 형제로 좁힌다. Tooltip/
+ * Popover 등 깊은 트리 안의 aria-hidden=true 는 의도된 inert 일 수 있어
+ * 훼손하면 안 된다.
  */
 export async function waitForDialogClosed(page: Page) {
   await expect(page.locator('[role="dialog"]')).toHaveCount(0);
   await page.evaluate(() => {
     document.body.style.removeProperty('overflow');
     document.body.style.removeProperty('pointer-events');
-    document.querySelectorAll('[aria-hidden="true"]').forEach((el) => {
-      if (!el.closest('[role="dialog"], [role="alertdialog"]')) {
+    document.querySelectorAll('body > [aria-hidden="true"]').forEach((el) => {
+      if (!el.querySelector('[role="dialog"], [role="alertdialog"]')) {
         el.removeAttribute('aria-hidden');
       }
     });

--- a/tests/unit/compute-bar-style.test.ts
+++ b/tests/unit/compute-bar-style.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { computeBarStyle } from '@/lib/gantt/compute-bar-style';
+
+describe('computeBarStyle', () => {
+  it('rangeStart과 같은 날 시작하는 7일짜리 막대 → left=0, width=(7-1+1)*dayWidth - 2', () => {
+    const result = computeBarStyle(
+      { rangeStart: '2026-05-01', dayWidth: 14 },
+      { startDate: '2026-05-01', dueDate: '2026-05-07' }
+    );
+    expect(result).toEqual({ leftPx: 0, widthPx: 96 });
+  });
+
+  it('하루짜리(시작=기한)는 한 칸 폭 - 2 만큼 = 12 (최소 너비 클램프와 일치)', () => {
+    const result = computeBarStyle(
+      { rangeStart: '2026-05-01', dayWidth: 14 },
+      { startDate: '2026-05-03', dueDate: '2026-05-03' }
+    );
+    expect(result).toEqual({ leftPx: 28, widthPx: 12 });
+  });
+
+  it('dayWidth가 매우 작아 일수*dayWidth - 2 가 12보다 작으면 12로 클램프', () => {
+    const result = computeBarStyle(
+      { rangeStart: '2026-05-01', dayWidth: 2 },
+      { startDate: '2026-05-01', dueDate: '2026-05-01' }
+    );
+    expect(result).toEqual({ leftPx: 0, widthPx: 12 });
+  });
+
+  it('월 경계 교차 (5/29 ~ 6/5) → width는 일수에 비례', () => {
+    const result = computeBarStyle(
+      { rangeStart: '2026-05-25', dayWidth: 10 },
+      { startDate: '2026-05-29', dueDate: '2026-06-05' }
+    );
+    expect(result).toEqual({ leftPx: 40, widthPx: 78 });
+  });
+
+  it('startDate가 null → null', () => {
+    expect(
+      computeBarStyle(
+        { rangeStart: '2026-05-01', dayWidth: 14 },
+        { startDate: null, dueDate: '2026-05-07' }
+      )
+    ).toBeNull();
+  });
+
+  it('dueDate가 null → null', () => {
+    expect(
+      computeBarStyle(
+        { rangeStart: '2026-05-01', dayWidth: 14 },
+        { startDate: '2026-05-01', dueDate: null }
+      )
+    ).toBeNull();
+  });
+
+  it('startDate, dueDate 모두 null → null', () => {
+    expect(
+      computeBarStyle(
+        { rangeStart: '2026-05-01', dayWidth: 14 },
+        { startDate: null, dueDate: null }
+      )
+    ).toBeNull();
+  });
+
+  it('rangeStart 이전에 시작하는 막대는 left가 음수', () => {
+    const result = computeBarStyle(
+      { rangeStart: '2026-05-10', dayWidth: 14 },
+      { startDate: '2026-05-08', dueDate: '2026-05-12' }
+    );
+    expect(result).toEqual({ leftPx: -28, widthPx: 68 });
+  });
+});

--- a/tests/unit/grid-range.test.ts
+++ b/tests/unit/grid-range.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { computeGridRange } from '@/lib/gantt/grid-range';
+
+describe('computeGridRange', () => {
+  it('작업 0건 → 오늘 -14d / +28d를 주 단위로 정규화', () => {
+    const today = new Date('2026-05-15T00:00:00Z');
+    const r = computeGridRange([], today);
+    expect(r.rangeStartIso).toBe('2026-04-26');
+    expect(r.end.toISOString().slice(0, 10)).toBe('2026-06-07');
+    expect(r.weeks).toHaveLength(6);
+    expect(r.totalDays).toBe(42);
+  });
+
+  it('작업 1건 → 오늘과 작업 날짜 중 min은 -7d, max는 +14d 패딩', () => {
+    const today = new Date('2026-05-15T00:00:00Z');
+    const r = computeGridRange(
+      [{ startDate: '2026-05-04', dueDate: '2026-05-08' }],
+      today
+    );
+    expect(r.rangeStartIso).toBe('2026-04-26');
+    expect(r.end.toISOString().slice(0, 10)).toBe('2026-05-24');
+    expect(r.weeks.map((w) => w.toISOString().slice(0, 10))).toEqual([
+      '2026-04-26',
+      '2026-05-03',
+      '2026-05-10',
+      '2026-05-17',
+    ]);
+    expect(r.months.map((m) => ({ label: m.label, weeks: m.weeks }))).toEqual([
+      { label: '2026년 4월', weeks: 1 },
+      { label: '2026년 5월', weeks: 3 },
+    ]);
+  });
+
+  it('startDate만 있고 dueDate는 비어 있는 작업도 dates에 포함', () => {
+    const today = new Date('2026-05-15T00:00:00Z');
+    const r = computeGridRange(
+      [{ startDate: '2026-04-01', dueDate: null }],
+      today
+    );
+    expect(r.weeks[0].toISOString().slice(0, 10)).toBe('2026-03-22');
+  });
+});


### PR DESCRIPTION
Closes #7

## Summary
- **간트형 일정 시각화 뷰** 추가 (SPEC.md §7 / USER_JOURNEY J13/J14/J16). 좌측 360px 작업 트리 + 우측 1fr 주 단위 그리드(월/주 2단 헤더, 오늘 accent 세로선). 막대는 시작일~기한 구간 + 내부 진행률 채움 + `{progress}%` 라벨, 일정 미설정은 빗금 "— 일정 없음 —" pill.
- **Claude Design 핸드오프 번들의 디자인 토큰**(`:root` CSS 변수, Inter / JetBrains Mono 폰트)과 헤더(`brand` + `view-toggle`) 이식 — 본 PR 범위 외(List 뷰 시각, Stats strip, Toast)는 후속 이슈로 분리.
- **읽기 전용**: SPEC §9 + J16에 따라 `<GanttBar>`/트랙에 `onPointerDown`/`onMouseDown`/`draggable` 일체 추가하지 않음. `isOverdue` prop도 추가하지 않음(이슈 #11 충돌 방지).

## TDD 증적
- `0b0343f` `test: #7 computeBarStyle 단위 테스트 (RED)` → import 실패로 RED.
- `418b0a0` `feat: #7 lib/gantt computeBarStyle + grid-range 유틸 (GREEN)` → 8 케이스 GREEN. ISO 'YYYY-MM-DD' 입력, UTC 일수 차로 left/width, 최소 너비 12px 클램프, 막대 사이 2px 간격.
- `3028354` `test: #7 J13/J14/J16 간트 뷰 E2E 시나리오 (RED)` → /gantt 라우트·`.gantt-*` 클래스 미존재로 RED.
- `c5effb3` `feat: #7 디자인 토큰 + view toggle + /gantt 라우트 스켈레톤` → CSS 변수·헤더·토글·빈 /gantt 페이지 등록. e2e 부분 GREEN.
- `e6d3d55` `feat: #7 GanttBoard + GanttBar 정밀 구현 (GREEN)` → e2e 풀 GREEN. Asia/Seoul 기준 todayIso 산출 → 클라이언트 컴포넌트 props.

## Test plan
- [x] `npm run lint` 로컬 초록불 (No ESLint warnings or errors)
- [x] `npm test` 로컬 초록불 (62 passed / 8 files)
- [x] `npm run build` 로컬 초록불 (/, /gantt 라우트 모두 빌드 성공)
- [x] `npx playwright test J13 J14 J16` 로컬 초록불 (3 passed)
- [ ] CI `lint-unit-build` 초록불 (PR 생성 직후 확인)
- [ ] CI `e2e` 초록불

## 관련 시나리오 (USER_JOURNEY.md)
- **J13** 간트 뷰로 전환 — 토글에서 "간트" 클릭 → `/gantt` 라우트, 좌측 트리 + 우측 그리드 + `.gantt-today` 세로선 + 일정 없는 행에 "일정 없음" 표기.
- **J14** 간트 막대의 진행률 채움 — 진행률 60%/30% 변경 시 `.gantt-bar-fill`의 inline `width: %` 정확.
- **J16** 간트는 읽기 전용 — 막대 드래그/리사이즈 시도 후 `boundingBox` 동일.

> **J15(간트 Overdue 시각 표시)는 이슈 #11**에 속한다. 본 PR이 globals.css `:root`에 `--danger`/`--danger-bg`/`--danger-border` 토큰을 미리 박아두므로 #11은 `.gantt-bar.overdue`·`.daterange.has-due-overdue`·`.overdue-badge` 룰만 추가하면 된다.

## 파일 변경 요약 (15)
| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `app/globals.css` | 신규 | 디자인 :root 토큰 + `.app-header`/`.brand`/`.view-toggle`/`.gantt-*` 클래스. **`.gantt-bar.overdue`는 미포함** (#11) |
| 2 | `app/layout.tsx` | 수정 | `next/font/google` Inter + JetBrains Mono → CSS 변수 노출, `globals.css` import |
| 3 | `app/page.tsx` | 수정 | Heading 제거, `<AppHeader />` 추가 |
| 4 | `app/gantt/page.tsx` | 신규 | Server Component. Asia/Seoul 기준 `todayIso` → `<GanttBoard nodes todayIso />` |
| 5 | `components/app-header.tsx` | 신규 | brand + ViewToggle 최소 형태(toolbar 통합은 별도 polish) |
| 6 | `components/view-toggle.tsx` | 신규 | `usePathname`으로 active 표기, `<Link>` 두 개 |
| 7 | `components/gantt-board.tsx` | 신규 | 'use client'. 좌/우 분할, `--week-count`/`--week-w` CSS 변수 주입, 막대 + 빗금 placeholder, 오늘 세로선 |
| 8 | `lib/gantt/compute-bar-style.ts` | 신규 | ISO 입력, left/width 픽셀 + null 분기 |
| 9 | `lib/gantt/grid-range.ts` | 신규 | min start - 1주 / max due + 2주 정규화, 작업 0건이면 오늘 ±기준, 월 그룹핑 라벨 |
| 10 | `tests/unit/compute-bar-style.test.ts` | 신규 | 8 케이스 |
| 11 | `tests/unit/grid-range.test.ts` | 신규 | 3 케이스 |
| 12 | `tests/e2e/J13-gantt-toggle.spec.ts` | 신규 | 토글·트리·오늘선·"일정 없음" |
| 13 | `tests/e2e/J14-gantt-progress-fill.spec.ts` | 신규 | 진행률 fill width 60%→30% |
| 14 | `tests/e2e/J16-gantt-readonly.spec.ts` | 신규 | 드래그/리사이즈 무반응 |
| 15 | `tests/e2e/_helpers/dialog.ts` | 신규 | 사전 존재 Chakra Dialog 잔재 워크어라운드 (#30) |

## 후속 이슈 (본 PR과 함께 정비)
- **#11** 본문 보강 — 디자인 시각 명세(빗금/outline/`overdue-badge`) + #7 머지 후 작업 명시.
- **#27** `[polish] List 뷰 디자인 정렬` 신규 — 디자인 번들의 `list-card`/`list-row` 그리드 컬럼·인덴트·avatar·status pill 적용. **회귀 위험**으로 본 PR과 분리.
- **#28** `[feat] 상단 요약 통계 카드` 신규 — Stats strip + 페이지 헤더. **SPEC §1 갱신 1차 PR 선행 필요**.
- **#29** `[polish] 액션 결과 토스트` 신규 — 작업 추가/저장/삭제/CSV 완료 알림.
- **#30** `[bug] Chakra v3 Dialog 닫힘 후 body scroll-lock 잔재` 신규 — `tests/e2e/_helpers/dialog.ts`의 워크어라운드 트래킹.

## 주의
- **드래그 편집 절대 금지** (SPEC §9, J16). 본 PR에 핸들러 일체 없음.
- **#11 충돌 방지** — `<GanttBar>`에 `isOverdue` prop 없음, `.gantt-bar.overdue` 룰도 globals.css에 추가하지 않음. #11은 룰만 추가하면 됨.
- **타임존**: `app/gantt/page.tsx`는 `Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Seoul' })`로 today를 산출. 한국어 사용자 기준 자정 직후에도 '오늘'이 어긋나지 않게.
- **사전 존재 Chakra flaky** — main 브랜치의 J3~J8/J10/J11이 로컬에서 같은 원인(Dialog 잔재 `body { pointer-events: none }`)으로 fail. 본 PR은 `_helpers/dialog.ts`로 신규 e2e만 안정화. 근본 수정은 #30에서 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
