### PR TITLE
docs: #33 위임 정책 §12 + README 워크플로우 + PORTABILITY 가이드

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,3 +302,60 @@ export default defineConfig({
 ### CI/CD (`.github/workflows/`)
 
 - `db-migrate.yml` — `main` 브랜치 push 시 `drizzle-kit migrate`를 `PRODUCTION_DATABASE_URL`에 실행
+
+## 12. 위임 정책 — 스킬과 OMC 서브에이전트
+
+이 저장소의 작업은 **스킬을 사용자 진입점**으로, **무거운 실행은 OMC 서브에이전트에 위임**한다. 목표는 (1) 메인 세션 prompt cache 보존, (2) 모델 스위치 비용 제거, (3) 학습 가시성 유지.
+
+### 진입점 우선순위
+
+1. **스킬이 있으면 스킬을 먼저 사용**한다 (`/plan-issue`, `/exec-plan`, `/raise-pr`, `/multi-agent-review`, `/manual-test`, `/dev-server`, `/setup-dev-environment`).
+2. 스킬이 없는 보조 작업은 **OMC 서브에이전트를 ad-hoc으로 호출**한다.
+3. 1~2줄 trivial 수정은 **메인이 직접** 처리한다 — 학습 가시성을 위해.
+
+### OMC 서브에이전트 라우팅
+
+스킬이 없거나 스킬 내부에서 호출할 때 사용. `Task(subagent_type="oh-my-claudecode:<name>", prompt=…)` 형태.
+
+| 상황 | 호출 |
+|---|---|
+| 코드베이스 광역 탐색 (3+ 위치) | `oh-my-claudecode:explore` (haiku, READ-ONLY) |
+| Plan에 따른 본격 구현 | `oh-my-claudecode:executor` (sonnet) — `/exec-plan`이 자동 호출 |
+| 막혔을 때 root-cause 진단 | `oh-my-claudecode:architect` (opus, READ-ONLY) |
+| 버그 재현·격리 | `oh-my-claudecode:debugger` 또는 `oh-my-claudecode:tracer` |
+| 어수선한 staging의 atomic 커밋 분리 | `oh-my-claudecode:git-master` (sonnet) |
+| 큰 변경 후 독립 검증 | `oh-my-claudecode:verifier` (sonnet) |
+| PR 단위 3관점 리뷰 | `/multi-agent-review` 스킬이 `code-reviewer` + `security-reviewer` + `test-engineer` 3병렬 호출 |
+
+### 모델 스위치 금지
+
+`/plan-issue`(Opus) → `/exec-plan` 흐름에서 **`/model` 명령으로 메인 모델을 바꾸지 말 것.** 모델 스위치는 prompt cache를 무효화해 SPEC.md / USER_JOURNEY.md / 코드 파일을 다시 읽는 비용이 발생한다.
+
+`/exec-plan`이 비-trivial plan을 OMC `executor` 서브에이전트(Sonnet, 자체 컨텍스트)에 자동 위임하므로, 메인 세션은 Opus를 유지한 채 Sonnet 비용 효과만 흡수할 수 있다.
+
+### 핸드오프 규칙
+
+- 서브에이전트 출력은 **요약만** 메인으로 가져온다 (변경 파일 목록, 검증 결과, 다음 단계).
+- 서브에이전트에 넘기는 프롬프트에는 **plan 절대 경로 + CLAUDE.md §6 / §9 / §10 인용**을 포함한다.
+- 서브에이전트가 plan에서 벗어나면 **즉시 멈추고 사용자에게 보고** — 자동 재계획 금지.
+- 같은 슬라이스에서 3회 연속 실패하면 OMC `architect` 서브에이전트로 cross-check 위임 또는 사용자에게 보고.
+
+### 검증 명령 (서브에이전트가 따라야 할 게이트)
+
+서브에이전트에 위임할 때 프롬프트에 박을 검증 명령:
+
+| 단계 | 명령 |
+|---|---|
+| 각 슬라이스 완료마다 | `npm run lint` → `npm test` |
+| 마지막 슬라이스 후 | `npm run build` |
+| 라우팅·UI 계약 변경 시 | `npm run test:e2e` |
+| 스키마 변경 시 | `npm run db:generate` → SQL 리뷰 → `npm run db:migrate` (§6 순서) |
+
+### 예외 — 메인이 직접 처리
+
+다음 경우엔 메인 세션이 직접 작업한다 (서브에이전트 위임 X).
+
+- 1~2줄 trivial fix (오타, import 추가, 한 줄 문구 수정)
+- 사용자가 "직접 해줘"라고 명시한 경우
+- Playwright MCP가 필요한 작업 (`/manual-test` 스킬은 메인 세션에서 브라우저 자동화)
+- 환경 진단·서버 기동 같이 Bash 백그라운드/시그널 모니터링이 필요한 작업 (`/setup-dev-environment`, `/dev-server`)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,64 @@ gh auth status
 
 ---
 
+## 🛠 개발 워크플로우 — 스킬 7개로 한 사이클
+
+이 저장소는 **이슈 하나를 끝낼 때마다 같은 7-스텝 사이클**을 돕니다. 모든 스텝은 슬래시 명령으로 시작하고, Claude가 알아서 적절한 OMC 서브에이전트에 위임합니다. 수강생은 명령 이름만 외우면 됩니다.
+
+```
+사이클 시작
+   │
+   ▼
+[1] /setup-dev-environment   ← 최초 1회 (도구 설치·로그인)
+[2] /dev-server              ← 매 세션 시작 (Supabase + Next.js)
+[3] /plan-issue <이슈번호>    ← Opus가 SPEC·USER_JOURNEY·TDD로 plan 작성
+   │      ↓ 사용자 승인
+[4] /exec-plan               ← 큰 plan은 OMC executor에 자동 위임 (Sonnet)
+   │      ↓ (UI 변경이 있으면)
+[5] /manual-test J<x>        ← Playwright로 화면 확인 + 스크린샷 증적
+   │
+[6] /raise-pr                ← push → PR → CI 감시 → 이슈 체크박스 갱신
+   │      ↓ CI 초록불 후
+[7] /multi-agent-review <PR#> ← 품질·보안·테스트 3관점 병렬 리뷰
+   │      ↓ 사용자 머지
+사이클 종료
+```
+
+### 각 스텝의 역할
+
+| # | 명령 | 무엇을 하는가 | 누가 실행 |
+|---|---|---|---|
+| 1 | `/setup-dev-environment` | Node·Docker·Supabase·Vercel·gh 설치/로그인 진단 | 메인 (Opus) |
+| 2 | `/dev-server` | Supabase 컨테이너 + `.env.local` 동기화 + `npm run dev` 기동 | 메인 |
+| 3 | `/plan-issue <N>` | 이슈 → SPEC·USER_JOURNEY 게이트 + TDD 슬라이스 plan을 `~/.claude/plans/`에 저장 | 메인 (Opus, 프로젝트 두뇌) |
+| 4 | `/exec-plan` | plan 실행. 비-trivial은 OMC `executor`(Sonnet)에 자동 위임 | 메인 → executor 자동 위임 |
+| 5 | `/manual-test J<x>` | USER_JOURNEY 시나리오를 브라우저로 시연, 스크린샷 저장 | 메인 (Playwright MCP 필요) |
+| 6 | `/raise-pr` | 로컬 `lint+test+build` → push → PR 본문 → CI 감시 → 이슈 체크박스 | 메인 |
+| 7 | `/multi-agent-review <PR#>` | code-reviewer / security-reviewer / test-engineer 병렬 리뷰 + 교차 검증 | 메인 → 3 OMC 서브에이전트 병렬 |
+
+### 왜 이 구조인가
+
+- **스킬 = 진입점**: 짧은 슬래시 명령만 외우면 됩니다.
+- **OMC 서브에이전트 = 내부 일꾼**: 무거운 구현·리뷰는 자체 컨텍스트의 서브에이전트가 흡수해 메인 토큰을 보존합니다.
+- **모델 스위치 없음**: 메인은 늘 Opus 유지. Sonnet 비용은 `executor` 위임을 통해 자동으로 발생합니다 (`/model` 명령으로 모델을 직접 바꾸지 마세요 — prompt cache가 무효화됩니다).
+- **학습 가시성**: Trivial 수정과 Playwright 시연은 메인이 직접 → 수강생이 단계별로 봅니다. 큰 구현만 위임 → 토큰을 절감합니다.
+
+### "어느 명령을 써야 할지 모르겠다" 디시전 트리
+
+```
+지금 막 클론했다           → /setup-dev-environment
+서버를 띄우고 싶다         → /dev-server
+이슈를 시작한다            → /plan-issue <N>
+plan은 있고 구현만 남았다  → /exec-plan
+화면을 직접 보고 싶다      → /manual-test J<x>
+구현이 끝나서 PR이 필요하다 → /raise-pr
+PR 머지 전 리뷰가 필요하다 → /multi-agent-review <PR#>
+```
+
+> 위임 정책의 자세한 규칙(라우팅 표·핸드오프·예외)은 [`CLAUDE.md` §12](./CLAUDE.md)를 참조하세요. 이 체계를 다른 저장소로 옮기는 방법은 [`docs/PORTABILITY.md`](./docs/PORTABILITY.md)에 정리돼 있습니다.
+
+---
+
 ## WBS 기능 스펙 (MVP)
 
 > **사용자 관점 전체 기능·화면 목업은 [`SPEC.md`](./SPEC.md)에 있습니다.** 여기서는 구현에 필요한 **데이터 모델 필드명**만 정리합니다. UX 동작(버튼 라벨, 목록·간트 화면 구성, Overdue 표시 방식 등)은 SPEC.md를 단일 원천으로 삼으세요.

--- a/docs/PORTABILITY.md
+++ b/docs/PORTABILITY.md
@@ -1,0 +1,173 @@
+# 이식성 — 다른 프로젝트로 이 체계 옮기기
+
+이 저장소가 쓰는 **"스킬 + OMC 서브에이전트 위임"** 체계를 다른 저장소에 그대로 옮기는 가이드입니다. 핵심 아이디어는 (1) **메인은 Opus 유지**, (2) **무거운 실행은 OMC 서브에이전트가 흡수**, (3) **스킬은 사용자 진입점**.
+
+`CLAUDE.md` §12에 명문화된 위임 정책을 다른 저장소에서 재현하려면 두 가지가 필요합니다:
+
+1. **글로벌 아키텍처 스킬 4개** — 프로젝트 무관, 한 번 설치하면 모든 저장소가 공유.
+2. **프로젝트 종속 스킬 3개** — 각 저장소의 스택·문서 구조에 맞게 그 저장소 안에 둠.
+
+---
+
+## 1. 무엇이 이식 가능하고 무엇이 프로젝트 종속인가
+
+| 자산 | 종류 | 이식 위치 |
+|---|---|---|
+| `/exec-plan` 스킬 (executor 위임 모드) | **아키텍처** | 글로벌 (`~/.claude/skills/`) — 어떤 프로젝트든 plan→executor 흐름 동일 |
+| `/raise-pr` 스킬 | 부분 아키텍처 + 부분 프로젝트 | 글로벌 코어 + per-project 검증 명령 오버라이드 |
+| `/multi-agent-review` 스킬 | **아키텍처** | 글로벌 — OMC 3 reviewer 호출은 프로젝트 무관 |
+| `/manual-test` 스킬 | 부분 아키텍처 + 부분 프로젝트 | 글로벌 (Playwright 패턴) + per-project (USER_JOURNEY 매핑) |
+| `/plan-issue` 스킬 | **프로젝트 종속** | per-project — SPEC/JOURNEY/스키마 게이트는 그 저장소 한정 |
+| `/dev-server` 스킬 | **프로젝트 종속** | per-project — 스택(Supabase/Docker/등)에 묶임 |
+| `/setup-dev-environment` 스킬 | **프로젝트 종속** | per-project — 필수 도구가 스택마다 다름 |
+| CLAUDE.md §12 (위임 정책) | **아키텍처** | per-project로 복사, 검증 명령만 교체 |
+| README 워크플로우 섹션 | 부분 종속 | per-project — 7-스텝 사이클은 동일, 검증 명령만 교체 |
+
+---
+
+## 2. 추천 전략: 글로벌 4 + per-project 3
+
+```
+~/.claude/skills/                  ← 글로벌 (한 번만 설치)
+├── exec-plan/SKILL.md
+├── raise-pr/SKILL.md
+├── multi-agent-review/SKILL.md
+└── manual-test/SKILL.md
+
+<신규 저장소>/.claude/skills/      ← per-project (저장소마다)
+├── plan-issue/SKILL.md
+├── dev-server/SKILL.md
+└── setup-dev-environment/SKILL.md
+```
+
+**왜 이 분리인가**:
+- 아키텍처 스킬 4개는 프로젝트 종속 정보가 거의 없어 글로벌화가 깔끔.
+- 프로젝트 종속 스킬 3개는 SPEC/스택/도구가 매번 다르므로 각 저장소가 자기 버전 보유.
+- 글로벌 스킬을 업데이트하면 모든 프로젝트가 동시에 혜택.
+
+---
+
+## 3. 글로벌 설치 (1회)
+
+자기 머신에서 한 번만 실행:
+
+```bash
+# 1. 이 저장소를 참조용으로 클론 (이미 있다면 패스)
+git clone https://github.com/junyoungDihisoft/claude-vercel-wbs ~/Dev/claude-vercel-wbs-ref
+
+# 2. 아키텍처 스킬 4개를 글로벌로 복사
+mkdir -p ~/.claude/skills
+cp -r ~/Dev/claude-vercel-wbs-ref/.claude/skills/exec-plan ~/.claude/skills/
+cp -r ~/Dev/claude-vercel-wbs-ref/.claude/skills/raise-pr ~/.claude/skills/
+cp -r ~/Dev/claude-vercel-wbs-ref/.claude/skills/multi-agent-review ~/.claude/skills/
+cp -r ~/Dev/claude-vercel-wbs-ref/.claude/skills/manual-test ~/.claude/skills/
+
+# 3. 확인 — Claude Code 재시작 후 /agents 또는 / 입력해서 자동완성에 4개 명령이 보이는지
+```
+
+> **글로벌 스킬 변수화**: 위 4개는 현재 이 저장소(WBS)의 검증 명령(`npm run lint`/`npm test`/`npm run build`)이 박혀있습니다. 다른 스택(예: pytest, cargo test)의 프로젝트에서도 자연스럽게 동작하려면 **각 프로젝트의 `CLAUDE.md` §12 검증 명령 표를 읽어 사용**하도록 글로벌 스킬을 한 번 손봐 주세요. 한 번 변수화하면 이후엔 그대로 재사용 가능.
+
+---
+
+## 4. 신규 프로젝트 부트스트랩 프롬프트
+
+신규 저장소를 클론한 직후 Claude Code 첫 세션에 **아래 코드블록 본문을 그대로 붙여넣으면** 셋업이 시작됩니다. README나 메모에 보관해두세요.
+
+```
+이 저장소에 "스킬 + OMC 서브에이전트 위임" 개발 체계를 셋업해줘. 다음 순서를 따른다.
+
+## 1. 프로젝트 진단 (병렬 Bash)
+다음을 한 번에 확인하고 5줄 표로 보여줘.
+- 빌드/테스트 매니페스트: package.json / pyproject.toml / Cargo.toml / go.mod / build.gradle / Makefile / *.xcodeproj 중 어느 것?
+- 주 언어 + 테스트 러너 + 린터 + 포맷터 추정
+- CI 설정 위치 (.github/workflows/, .gitlab-ci.yml 등)
+- 기존 CLAUDE.md / .claude/ / README.md 존재 여부
+- 스펙 문서(SPEC.md, docs/spec.md, requirements.md) + 시나리오 문서(USER_JOURNEY.md, tests/scenarios.md) 존재 여부
+- ~/.claude/skills/ 에 exec-plan / raise-pr / multi-agent-review / manual-test 가 글로벌 설치되어 있는지
+
+## 2. 글로벌 아키텍처 스킬 설치 확인
+글로벌 4개 스킬이 없으면 사용자에게 안내(자동 실행 X):
+
+  git clone https://github.com/junyoungDihisoft/claude-vercel-wbs ~/Dev/claude-vercel-wbs-ref
+  cp -r ~/Dev/claude-vercel-wbs-ref/.claude/skills/{exec-plan,raise-pr,multi-agent-review,manual-test} ~/.claude/skills/
+
+설치 확인 후 다음 단계로.
+
+## 3. 프로젝트 종속 자산 생성/수정 (사용자 승인 단계별)
+
+### 3-A. CLAUDE.md
+없으면 신규 생성 (스택·금기사항·디렉토리 규약 자동 추정).
+있으면 §12 "위임 정책" 섹션을 마지막에 추가:
+- 진입점 우선순위 (스킬 → OMC ad-hoc → 메인 직접)
+- OMC 서브에이전트 라우팅 표 (explore/executor/architect/debugger/git-master/verifier 등)
+- 모델 스위치 금지 단락
+- 핸드오프 규칙 (요약만, plan 절대경로 + 프로젝트 규약 인용)
+- 검증 명령 표 (1단계 진단 결과로 채움)
+- 예외 (trivial / 인터랙티브 도구 / 환경 작업은 메인 직접)
+
+### 3-B. .claude/skills/plan-issue/SKILL.md (프로젝트 종속, 신규)
+다음 변수를 채워 생성:
+- 스펙 문서 경로 (있으면), 시나리오 문서 경로 (있으면)
+- TDD 슬라이스 단위 (RED/GREEN/REFACTOR 또는 사용자 선호)
+- 스키마/마이그레이션 워크플로우 (DB 사용 시)
+- 검증 명령 (1단계 진단 결과)
+스펙 문서가 없으면 "이슈 본문만 보고 진행" 모드로 단순화.
+
+### 3-C. .claude/skills/dev-server/SKILL.md (프로젝트 종속, 신규)
+프로젝트 스택에 맞춰:
+- 의존성 컨테이너 기동 명령 (docker compose, supabase start, devcontainer 등)
+- 환경변수 동기화 절차
+- 개발 서버 기동 명령 (1단계 진단 결과의 dev script)
+
+### 3-D. .claude/skills/setup-dev-environment/SKILL.md (프로젝트 종속, 신규)
+필수 도구(node/python/rustup/docker/CI CLI 등) 진단 + 설치 가이드.
+
+### 3-E. README.md
+"개발 워크플로우 — 스킬 7개로 한 사이클" 섹션 추가:
+- ASCII 사이클 다이어그램
+- 7행 명령 표 (1단계 진단된 검증 명령으로 채움)
+- "왜 이 구조인가" 4불릿
+- "어느 명령을 써야 할지 모르겠다" 디시전 트리
+
+## 4. 검증
+- find .claude -type f
+- grep -n "## 12" CLAUDE.md
+- grep -n "스킬 7개" README.md
+- 사용자에게 "Claude Code 재시작 후 /plan-issue, /exec-plan, /raise-pr, /multi-agent-review, /manual-test, /dev-server, /setup-dev-environment 가 모두 / 자동완성에 보이는지 확인" 안내.
+
+## 5. 커밋
+- chore: claude code skill+OMC 서브에이전트 체계 부트스트랩 (한 커밋, 또는 사용자 선호에 따라 분할)
+- .gitignore 에 .claude/settings.local.json 만 추가 (이미 있으면 패스). .claude/skills/ 는 팀 공유용 — 절대 ignore 금지.
+
+## 가드레일
+- 자동 실행 금지: git push / git commit --no-verify / gh pr merge / rm -rf
+- 기존 파일 덮어쓰기 전에 반드시 diff 보여주고 사용자 승인.
+- 스펙/시나리오 문서가 없으면 "없는 상태로 진행할지, 빈 템플릿을 만들지" 사용자 질문.
+- 글로벌 스킬을 손대지 않는다 (per-project 범위만).
+- OMC가 깔려있어야 함 — ~/.claude/CLAUDE.md 에 oh-my-claudecode 언급이 있는지 1단계에 확인 추가.
+- 영어 프로젝트면 생성되는 모든 본문을 영어로 통일하도록 지시.
+```
+
+---
+
+## 5. 점진적 확장 — `/install-tdd-pipeline` 메타-스킬 (선택)
+
+위 부트스트랩 프롬프트를 2~3 프로젝트에 적용해 안정화한 뒤, 동일 본문을 `~/.claude/skills/install-tdd-pipeline/SKILL.md` 로 박으면 신규 저장소에서 `/install-tdd-pipeline` 한 줄로 셋업이 가능합니다. 본 가이드 범위 밖 — 후속 이슈 후보.
+
+---
+
+## 6. 이식 시 주의사항
+
+- **OMC가 깔려있어야 함**: 신규 머신·환경에 [oh-my-claudecode](https://github.com/) 가 없으면 `oh-my-claudecode:executor` / `code-reviewer` 등 호출이 모두 실패합니다. 부트스트랩 1단계에 `~/.claude/CLAUDE.md` 에 `oh-my-claudecode` 언급이 있는지 확인하는 진단을 추가하세요.
+- **언어 선택**: 본 저장소는 한국어 톤. 영어 프로젝트로 옮길 땐 부트스트랩 프롬프트의 한국어 본문을 영어로 바꾸고, 생성되는 스킬 본문도 영어로 통일하도록 지시 추가.
+- **스펙 문서 부재**: SPEC.md / USER_JOURNEY.md 같은 문서가 없는 프로젝트에서는 `plan-issue` 스킬의 게이트 단계가 "이슈 본문만 보고 진행"으로 단순화돼야 합니다. 부트스트랩 §3-B에서 분기.
+- **CI 부재**: GitHub Actions가 없으면 `/raise-pr` Phase 3(CI 감시) 단계는 skip. 부트스트랩이 CI 진단 결과로 자동 분기하도록 명시.
+- **모노레포**: 한 저장소에 여러 패키지가 있으면 `/exec-plan` 위임 시 executor 프롬프트에 "작업 디렉토리"를 명시해야 합니다. CLAUDE.md §12 검증 명령 표를 패키지별로 분리하는 것을 고려.
+
+---
+
+## 7. 참고
+
+- 위임 정책 본문: [`../CLAUDE.md`](../CLAUDE.md) §12
+- 워크플로우 사이클: [`../README.md`](../README.md) "🛠 개발 워크플로우 — 스킬 7개로 한 사이클" 섹션
+- 설계 plan: `~/.claude/plans/tingly-wiggling-platypus.md` §11


### PR DESCRIPTION
Closes #33

## Summary
- `CLAUDE.md` §12 신설 — 스킬은 진입점, 무거운 실행은 OMC 서브에이전트 위임이라는 라우팅 원칙을 명문화. `/model` 스위치 금지 가드와 핸드오프 규칙도 박음.
- `README.md`에 "🛠 개발 워크플로우 — 스킬 7개로 한 사이클" 섹션 추가. ASCII 다이어그램 + 7행 명령 표 + 디시전 트리.
- `docs/PORTABILITY.md` 신설 — 다른 저장소에 이 체계를 옮기는 가이드. 글로벌 4 + per-project 3 분리 전략, 글로벌 설치 명령, **신규 저장소에 그대로 붙여넣을 부트스트랩 프롬프트(코드블록)** 포함.

선행: PR #34 (`/exec-plan` 스킬 개편) 머지 완료. 본 PR은 그 결과를 문서화.

## Test plan
- [x] `npm run lint` 로컬 초록불 (exit 0)
- [x] `npm test` 로컬 초록불 (exit 0)
- [x] `npm run build` 로컬 초록불 (exit 0)
- [x] grep 검증: `^## 12` (CLAUDE.md), `스킬 7개로 한 사이클` (README), `^## [1-7]\.` 7섹션 (PORTABILITY.md) 모두 매치
- [x] CI `lint + vitest + build` 초록불 ✅
- [x] CI `playwright e2e (chromium)` 초록불 ✅

## 파일 변경 요약
| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `CLAUDE.md` | 수정 | §12 위임 정책 신설 (라우팅 표·모델 스위치 금지·핸드오프·검증 명령·예외, +57줄) |
| 2 | `README.md` | 수정 | "🛠 개발 워크플로우 — 스킬 7개로 한 사이클" 섹션 추가 (사이클 다이어그램·명령 표·디시전 트리, +58줄) |
| 3 | `docs/PORTABILITY.md` | 신규 | 이식 전략 + 글로벌 설치 + 부트스트랩 프롬프트 + 주의사항 (+173줄) |

## 주의 (있을 때만)
- 코드(`app/`, `lib/`, `components/`, `drizzle/`) · 스키마 · 테스트 · CI 파일 무변경. 문서만.
- `docs/PORTABILITY.md` 안의 부트스트랩 프롬프트는 **신규 저장소에서 그대로 붙여넣어 동작**해야 함. 다음 신규 프로젝트 적용 시 미세 조정 필요할 수 있음 — 발견되면 별도 이슈로.

## 후속
- (선택) `/install-tdd-pipeline` 메타-스킬 작성 — 부트스트랩 프롬프트가 안정화되면 동일 본문을 `~/.claude/skills/install-tdd-pipeline/SKILL.md`로 박아 신규 저장소에서 슬래시 한 줄로 셋업 가능. 본 PR 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
