### PR TITLE
ci: #9 PRODUCTION_DATABASE_URL 가드 제거 — db-migrate 실 적용

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -50,16 +50,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Issue #9 에서 PRODUCTION_DATABASE_URL secret 을 등록하기 전까지는
-      # 이 스텝이 no-op 로 끝난다. secret 이 비어 있으면 drizzle-kit 이
-      # 호출되지 않아 이전(#1~#7) PR 머지마다 이 워크플로우가 실패하지 않는다.
-      # #9 에서 secret 등록과 함께 아래 가드(첫 다섯 줄)를 제거할 것.
       - name: Apply Drizzle migrations
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
-        run: |
-          if [ -z "$DATABASE_URL" ]; then
-            echo "::warning::PRODUCTION_DATABASE_URL 미설정 — 이슈 #9 완료 전이라 마이그레이션을 건너뜁니다."
-            exit 0
-          fi
-          npx drizzle-kit migrate
+        run: npx drizzle-kit migrate


### PR DESCRIPTION
Closes #9

## Summary

- `production` environment 의 `PRODUCTION_DATABASE_URL` secret 등록 (수동, 본 PR 외부) 이 끝났으므로 `db-migrate.yml` 의 노옵 가드를 제거해 `npx drizzle-kit migrate` 가 실제로 원격 Supabase 에 적용되도록 한다.
- README §"원격 배포 → 2)" / CLAUDE.md §6 "원격(프로덕션) 마이그레이션 적용은 GitHub Actions 가 담당한다" 의 자동화를 비로소 살리는 변경.

## ⚠️ 이 PR 의 검증 한계 (중요)

`db-migrate.yml` 은 **PR 에서 돌지 않습니다** (`branches: [main]` 푸시 + `paths` 필터). 따라서 본 PR 의 `ci.yml`(lint + vitest + build + e2e) 통과는 **본 변경의 안전성을 직접 입증하지 않습니다.**

진짜 검증은 머지 직후 트리거되는 `DB Migrate (Production)` 워크플로우 실행 결과로만 가능합니다 (이슈 #9 의 두 번째 체크박스). 머지 후 다음을 확인:

1. Actions 탭 → `DB Migrate (Production)` 최신 런 ✅
2. Supabase Studio → Table Editor 에 `tasks` 테이블 존재 + check constraint (`tasks_status_check`, `tasks_progress_check`)

실패 시 `PRODUCTION_DATABASE_URL` 값이 6543(Transaction pooler) 일 가능성이 가장 큼 → 5432 (Direct/Session) 로 교체 후 `workflow_dispatch` 재트리거.

## TDD 증적

이슈 본문에 명시된 **TDD 적용 예외** (CI 파이프라인 검증은 워크플로우 실행 자체가 E2E 테스트). 단위 테스트 없음.

## Test plan

- [x] `npm run lint` 로컬 초록불
- [x] `npm test` 로컬 초록불
- [x] `npm run build` 로컬 초록불
- [x] CI `lint + vitest + build` 초록불 ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25087709455/job/73506783861), 1m21s)
- [x] CI `playwright e2e (chromium)` 초록불 ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25087709455/job/73506783866), 2m18s)
- [ ] **(머지 후)** `DB Migrate (Production)` 워크플로우 ✅
- [ ] **(머지 후)** 원격 Supabase `tasks` 테이블 + 두 check constraint 확인 — 아래 SQL

## 머지 후 검증 절차 (수강생 본인이 직접 수행)

머지 직후 자동 발화하는 `DB Migrate (Production)` 워크플로우가 ✅로 끝나면, **이슈 #9 의 두 체크박스를 본인이 직접 [x]로 전환하고 이슈를 close** 합니다. 두 체크박스는 머지 전 PR/CI 단계에서 자동으로 채울 수 없는 항목이라 의도적으로 [ ]로 남겨둡니다.

**1) Actions 탭 — 워크플로우 ✅ 확인**
```bash
gh run list --workflow=db-migrate.yml --limit 1
# conclusion: success 가 떠야 함
```

**2) Supabase Cloud → SQL Editor — `tasks` 테이블 + check constraint 확인**

```sql
SELECT conname, pg_get_constraintdef(oid)
FROM pg_constraint
WHERE conrelid = 'public.tasks'::regclass
  AND contype = 'c';
```

기대 결과 (정의는 `lib/db/schema.ts` 의 `statusCheck` / `progressCheck` 와 일치):

| conname | pg_get_constraintdef |
|---|---|
| `tasks_status_check` | `CHECK (status = ANY (ARRAY['todo'::text, 'doing'::text, 'done'::text]))` |
| `tasks_progress_check` | `CHECK (progress >= 0 AND progress <= 100)` |

두 줄이 보이지 않으면 워크플로우가 제대로 적용되지 않은 것 — 이슈 #9 본문의 "함정" 섹션 참고 (6543/secret 누락 등).

## 후속 이슈 (multi-agent-review 산출)

본 PR 이후 별도 이슈로 트래킹:
- C1 — `db-migrate.yml` 5432 포트 사전 가드 (6543 오등록 시 명시적 실패 메시지)
- C5 — `actionlint` CI 도입 (워크플로우 변경의 자동 검증)


## 파일 변경 요약

| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `.github/workflows/db-migrate.yml` | 수정 | 가드 4줄 + 안내 주석 4줄 제거. `environment: production` / `env.DATABASE_URL` 매핑 보존 |

```diff
-      # Issue #9 에서 PRODUCTION_DATABASE_URL secret 을 등록하기 전까지는
-      # 이 스텝이 no-op 로 끝난다. ...
-      # #9 에서 secret 등록과 함께 아래 가드(첫 다섯 줄)를 제거할 것.
       - name: Apply Drizzle migrations
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
-        run: |
-          if [ -z "$DATABASE_URL" ]; then
-            echo "::warning::PRODUCTION_DATABASE_URL 미설정 — ..."
-            exit 0
-          fi
-          npx drizzle-kit migrate
+        run: npx drizzle-kit migrate
```

## 관련 시나리오 (USER_JOURNEY.md)

해당 없음 — 본 변경은 사용자 화면 기능이 아니라 배포 인프라.

## 주의

- CLAUDE.md §10 금기사항 환기: secret 값은 **port 5432 (Direct/Session)** 여야 함. 6543 (Transaction pooler) 은 prepared statement 충돌로 실패.
- `drizzle-kit migrate` 는 journal 테이블 기반 멱등 — 머지 후 재실행돼도 no-op.
- `concurrency.group: db-migrate-production` 으로 동시 런 직렬화. 정체 시 Actions UI 에서 cancel 후 재트리거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
