### PR TITLE
feat: #11 목표 기한 지남(overdue) Task 시각 표시

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -339,3 +339,4 @@ body {
 }
 .daterange.has-due-overdue .due { color: var(--danger); font-weight: 500; }
 .overdue-badge { background: var(--danger-bg); color: var(--danger); border: 1px solid var(--danger-border); padding: 1px 6px; border-radius: 4px; font-size: 10px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; margin-left: 6px; }
+.gantt-bar.overdue { outline: 1.5px solid var(--danger); outline-offset: 0; background-image: repeating-linear-gradient(45deg, transparent 0, transparent 5px, rgba(220,38,38,0.08) 5px, rgba(220,38,38,0.08) 10px); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -337,3 +337,5 @@ body {
   white-space: nowrap;
   pointer-events: none;
 }
+.daterange.has-due-overdue .due { color: var(--danger); font-weight: 500; }
+.overdue-badge { background: var(--danger-bg); color: var(--danger); border: 1px solid var(--danger-border); padding: 1px 6px; border-radius: 4px; font-size: 10px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; margin-left: 6px; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { tasks } from '@/lib/db/schema';
 import { TaskList } from '@/components/task-list';
 import { AppHeader } from '@/components/app-header';
 import { buildTaskTree } from '@/lib/tree/build-task-tree';
+import { getTodayIso } from '@/lib/dates/today-iso';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,7 +18,7 @@ export default async function HomePage() {
     <>
       <AppHeader />
       <Container maxW="5xl" py={8}>
-        <TaskList nodes={tree} />
+        <TaskList nodes={tree} todayIso={getTodayIso()} />
       </Container>
     </>
   );

--- a/components/gantt-board.tsx
+++ b/components/gantt-board.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties } from 'react';
 import type { TaskNode } from '@/lib/tree/build-task-tree';
 import { computeGridRange, todayOffsetDays } from '@/lib/gantt/grid-range';
 import { computeBarStyle } from '@/lib/gantt/compute-bar-style';
+import { isOverdue } from '@/lib/tasks/is-overdue';
 
 const WEEK_WIDTH_PX = 96;
 const DAY_WIDTH_PX = WEEK_WIDTH_PX / 7;
@@ -111,6 +112,7 @@ export function GanttBoard({ nodes, todayIso }: GanttBoardProps) {
                 { startDate: n.task.startDate, dueDate: n.task.dueDate }
               );
               const isDone = n.task.status === 'done';
+              const overdue = isOverdue(n.task, todayIso);
               return (
                 <div className="gantt-grid-row" key={n.task.id}>
                   {range.weeks.map((w, i) => (
@@ -121,7 +123,7 @@ export function GanttBoard({ nodes, todayIso }: GanttBoardProps) {
                   ))}
                   {bar ? (
                     <div
-                      className={`gantt-bar ${isDone ? 'is-done' : ''}`}
+                      className={`gantt-bar ${isDone ? 'is-done' : ''} ${overdue ? 'overdue' : ''}`}
                       style={{ left: bar.leftPx, width: bar.widthPx }}
                     >
                       <div className="gantt-bar-fill" style={{ width: `${n.task.progress}%` }} />

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -15,9 +15,10 @@ import type { TaskNode } from '@/lib/tree/build-task-tree';
 
 interface TaskListProps {
   nodes: TaskNode[];
+  todayIso: string;
 }
 
-export function TaskList({ nodes }: TaskListProps) {
+export function TaskList({ nodes, todayIso }: TaskListProps) {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | undefined>(undefined);
   const [parentId, setParentId] = useState<string | null>(null);
@@ -175,6 +176,7 @@ export function TaskList({ nodes }: TaskListProps) {
                 onEdit={handleEditClick}
                 onDelete={handleDeleteClick}
                 onAddSubtask={handleAddSubtask}
+                todayIso={todayIso}
               />
             ))}
           </Table.Body>

--- a/components/task-row.tsx
+++ b/components/task-row.tsx
@@ -4,6 +4,7 @@ import { Box, Button, HStack, Table, Text } from '@chakra-ui/react';
 import { useTransition } from 'react';
 import { cycleTaskStatus } from '@/app/actions/tasks';
 import type { Task } from '@/lib/types';
+import { isOverdue } from '@/lib/tasks/is-overdue';
 
 const STATUS_CONFIG = {
   todo: { label: '할 일', colorPalette: 'gray' },
@@ -20,6 +21,7 @@ interface TaskRowProps {
   onEdit: (task: Task) => void;
   onDelete: (task: Task) => void;
   onAddSubtask: (task: Task) => void;
+  todayIso: string;
 }
 
 export function TaskRow({
@@ -31,8 +33,10 @@ export function TaskRow({
   onEdit,
   onDelete,
   onAddSubtask,
+  todayIso,
 }: TaskRowProps) {
   const [isPending, startTransition] = useTransition();
+  const overdue = isOverdue(task, todayIso);
 
   const statusConfig =
     STATUS_CONFIG[task.status as keyof typeof STATUS_CONFIG] ??
@@ -82,7 +86,12 @@ export function TaskRow({
       </Table.Cell>
       <Table.Cell>{task.progress}%</Table.Cell>
       <Table.Cell>{task.startDate ?? '—'}</Table.Cell>
-      <Table.Cell>{task.dueDate ?? '—'}</Table.Cell>
+      <Table.Cell>
+        <span className={`daterange ${overdue ? 'has-due-overdue' : ''}`}>
+          <span className="due">{task.dueDate ?? '—'}</span>
+          {overdue && <span className="overdue-badge">지남</span>}
+        </span>
+      </Table.Cell>
       <Table.Cell>
         <HStack gap={1}>
           <Button size="xs" variant="outline" onClick={() => onEdit(task)}>

--- a/lib/tasks/is-overdue.ts
+++ b/lib/tasks/is-overdue.ts
@@ -1,0 +1,11 @@
+import type { Task } from '@/lib/types';
+
+// 'YYYY-MM-DD' 문자열은 사전순 = 시간순이므로 Date 변환 없이 strict < 비교만으로 충분하다.
+export function isOverdue(
+  task: Pick<Task, 'dueDate' | 'status'>,
+  todayIso: string,
+): boolean {
+  if (!task.dueDate) return false;
+  if (task.status === 'done') return false;
+  return task.dueDate < todayIso;
+}

--- a/tests/e2e/J15-gantt-overdue.spec.ts
+++ b/tests/e2e/J15-gantt-overdue.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { waitForDialogClosed } from './_helpers/dialog';
+import { isoDateOffset } from './_helpers/dates';
+
+test.describe('J15 — 간트 뷰 overdue 시각 표시', () => {
+  test('기한 지난 미완료 작업 간트 막대에 overdue 클래스 → 완료 전환 시 해제', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    const taskTitle = `J15 간트초과 ${Date.now()}`;
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.locator('input[type="date"]').nth(0).fill(isoDateOffset(-7));
+    await page.locator('input[type="date"]').nth(1).fill(isoDateOffset(-3));
+    await page.getByRole('button', { name: '추가' }).click();
+    await waitForDialogClosed(page);
+    await expect(page.getByText(taskTitle)).toBeVisible();
+
+    // 간트 진입
+    await page.getByRole('link', { name: '간트' }).click();
+    await expect(page).toHaveURL(/\/gantt$/);
+
+    // J14 패턴: 좌측 행 인덱스 찾고 같은 인덱스의 우측 .gantt-bar 확인
+    const idx = await page.evaluate((t) => {
+      const rows = Array.from(document.querySelectorAll('.gantt-row-left'));
+      return rows.findIndex((r) => (r.textContent ?? '').includes(t));
+    }, taskTitle);
+    expect(idx).toBeGreaterThanOrEqual(0);
+
+    const bar = page.locator('.gantt-grid-row').nth(idx).locator('.gantt-bar');
+    await expect(bar).toBeVisible();
+    await expect(bar).toHaveClass(/overdue/);
+
+    // 목록으로 돌아가 상태 → 완료
+    await page.getByRole('link', { name: '목록' }).click();
+    await expect(page).toHaveURL(/\/$/);
+    const row = page.getByRole('row').filter({ hasText: taskTitle });
+    await row.getByRole('button', { name: '할 일' }).click();
+    await expect(row.getByText('진행 중')).toBeVisible();
+    await row.getByRole('button', { name: '진행 중' }).click();
+    await expect(row.getByText('완료')).toBeVisible();
+
+    // 간트 재진입 → overdue 클래스 없음
+    await page.getByRole('link', { name: '간트' }).click();
+    await expect(page).toHaveURL(/\/gantt$/);
+    const idx2 = await page.evaluate((t) => {
+      const rows = Array.from(document.querySelectorAll('.gantt-row-left'));
+      return rows.findIndex((r) => (r.textContent ?? '').includes(t));
+    }, taskTitle);
+    expect(idx2).toBeGreaterThanOrEqual(0);
+    const bar2 = page.locator('.gantt-grid-row').nth(idx2).locator('.gantt-bar');
+    await expect(bar2).not.toHaveClass(/overdue/);
+  });
+});

--- a/tests/e2e/J9-list-overdue.spec.ts
+++ b/tests/e2e/J9-list-overdue.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { waitForDialogClosed } from './_helpers/dialog';
+import { isoDateOffset } from './_helpers/dates';
+
+test.describe('J9 — 목록 뷰 overdue 시각 표시', () => {
+  test('기한 지난 미완료 작업에 overdue 표시 → 완료 전환 시 즉시 해제', async ({ page }) => {
+    await page.goto('/');
+
+    const taskTitle = `J9 기한초과 ${Date.now()}`;
+    await page.getByRole('button', { name: '+ 작업 추가' }).click();
+    await page.getByPlaceholder('작업 제목').fill(taskTitle);
+    await page.locator('input[type="date"]').nth(0).fill(isoDateOffset(-7));
+    await page.locator('input[type="date"]').nth(1).fill(isoDateOffset(-3));
+    await page.getByRole('button', { name: '추가' }).click();
+    await waitForDialogClosed(page);
+    await expect(page.getByText(taskTitle)).toBeVisible();
+
+    const row = page.getByRole('row').filter({ hasText: taskTitle });
+
+    // overdue 클래스 및 배지 확인
+    await expect(row.locator('.daterange.has-due-overdue')).toBeVisible();
+    await expect(row.locator('.overdue-badge')).toBeVisible();
+    await expect(row.locator('.overdue-badge')).toHaveText('지남');
+
+    // 상태 배지 두 번 클릭 → 완료
+    await row.getByRole('button', { name: '할 일' }).click();
+    await expect(row.getByText('진행 중')).toBeVisible();
+    await row.getByRole('button', { name: '진행 중' }).click();
+    await expect(row.getByText('완료')).toBeVisible();
+
+    // overdue 표시 해제 확인
+    await expect(row.locator('.daterange.has-due-overdue')).toHaveCount(0);
+    await expect(row.locator('.overdue-badge')).toHaveCount(0);
+  });
+});

--- a/tests/unit/is-overdue.test.ts
+++ b/tests/unit/is-overdue.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { isOverdue } from '@/lib/tasks/is-overdue';
+
+describe('isOverdue', () => {
+  const today = '2026-04-29';
+
+  it('dueDate < today + status=doing → true', () => {
+    expect(isOverdue({ dueDate: '2026-04-26', status: 'doing' }, today)).toBe(true);
+  });
+
+  it('dueDate < today + status=todo → true', () => {
+    expect(isOverdue({ dueDate: '2026-04-26', status: 'todo' }, today)).toBe(true);
+  });
+
+  it('dueDate < today + status=done → false (완료된 작업은 overdue 아님)', () => {
+    expect(isOverdue({ dueDate: '2026-04-26', status: 'done' }, today)).toBe(false);
+  });
+
+  it('dueDate === today (경계) → false (strict <)', () => {
+    expect(isOverdue({ dueDate: '2026-04-29', status: 'todo' }, today)).toBe(false);
+  });
+
+  it('dueDate > today → false', () => {
+    expect(isOverdue({ dueDate: '2026-05-10', status: 'todo' }, today)).toBe(false);
+  });
+
+  it('dueDate === null → false (기한 없으면 판정 불가)', () => {
+    expect(isOverdue({ dueDate: null, status: 'todo' }, today)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #11

## Summary
- SPEC.md §H — 목표 기한이 지난 미완료 작업을 목록·간트 두 뷰에서 동일 판정으로 시각 강조 (`dueDate < today && status !== 'done'`).
- 데이터 모델 변경 없음. 파생값을 순수 함수 `isOverdue(task, todayIso)` 로 계산해 클래스/배지만 토글.
- 상태를 `done`으로 바꾸면 두 뷰의 경고 표시가 즉시 사라진다 (USER_JOURNEY J9, J15).

## TDD 증적
- `919525b` `test: #11 isOverdue 순수 함수 단위 테스트 (RED)` → `Cannot find module '@/lib/tasks/is-overdue'`로 RED. 6 케이스(경계 `==today`, `done`, `null`, 과거+todo/doing, 미래).
- `e9ec8c7` `feat: #11 isOverdue 순수 함수 (GREEN)` → `lib/tasks/is-overdue.ts`. 'YYYY-MM-DD' lexicographic == chronological 비교.
- `f94abca` `test: #11 J9 목록 뷰 overdue E2E (RED)` → `.daterange.has-due-overdue` + `.overdue-badge("지남")` 셀렉터 부재로 RED.
- `279bcc4` `feat: #11 목록 뷰 overdue 시각 표시 (GREEN — J9 통과)` → `app/page.tsx`에서 `getTodayIso()` prop 흘림 → `task-list.tsx` → `task-row.tsx`. globals.css에 `.daterange.has-due-overdue .due` + `.overdue-badge` 룰 추가.
- `194ed31` `test: #11 J15 간트 뷰 overdue E2E (RED)` → `.gantt-bar.overdue` 부재로 RED.
- `2334c4f` `feat: #11 간트 막대 overdue 시각 표시 (GREEN — J15 통과)` → `gantt-board.tsx`에서 기존 `todayIso` prop 재사용해 `isOverdue` 호출, className에 `overdue` 합성. globals.css `.gantt-bar.overdue` 룰(outline + 빗금 오버레이) 추가.

## Test plan
- [x] `npm run lint` 로컬 초록불 (No ESLint warnings or errors)
- [x] `npm test` 로컬 초록불 (9 files / 68 passed)
- [x] `npm run build` 로컬 초록불
- [x] CI `lint + vitest + build` 초록불 (1m27s — [run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25093070264/job/73523416579))
- [x] CI `playwright e2e (chromium)` 초록불 — J9·J15 포함 (2m31s — [run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25093070264/job/73523416578))

## 파일 변경 요약 (9)
| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `lib/tasks/is-overdue.ts` | 신규 | 순수 판정 함수. `Pick<Task, 'dueDate' \| 'status'>` + `todayIso: string` |
| 2 | `tests/unit/is-overdue.test.ts` | 신규 | 6 단위 테스트 케이스 |
| 3 | `tests/e2e/J9-list-overdue.spec.ts` | 신규 | J9 시나리오 (목록) |
| 4 | `tests/e2e/J15-gantt-overdue.spec.ts` | 신규 | J15 시나리오 (간트) |
| 5 | `app/page.tsx` | 수정 | `<TaskList todayIso={getTodayIso()} />` |
| 6 | `components/task-list.tsx` | 수정 | `todayIso` prop 흘림 → `<TaskRow>` |
| 7 | `components/task-row.tsx` | 수정 | 기한 셀에 `.daterange` 래퍼 + `.due` span + 조건부 `.overdue-badge` |
| 8 | `components/gantt-board.tsx` | 수정 | `.gantt-bar` className에 `overdue` 합성 |
| 9 | `app/globals.css` | 수정 | `.daterange.has-due-overdue .due`, `.overdue-badge`, `.gantt-bar.overdue` 룰 추가 |

총 +152 / -4.

## 관련 시나리오 (USER_JOURNEY.md)
- **J9** 목록 뷰 overdue — 빨강 날짜 + "지남" 배지, `done` 전환 시 즉시 해제.
- **J15** 간트 뷰 overdue — 막대 outline 경고 테두리 + 45° 빗금 오버레이, `done` 전환 시 즉시 해제. (J9와 동일 task로 두 뷰가 같은 판정을 내는지 검증)

## 주의
- SPEC.md §A-4 목업은 "기간" 단일 컬럼이지만 현재 구현은 "시작일/기한" 두 컬럼 — 컬럼 통합은 별도 polish 이슈로 분리하고, 본 PR은 기존 "기한" 셀 안에 `.daterange` 래퍼만 추가해 이슈 본문이 요구한 CSS 셀렉터 계약(`.daterange.has-due-overdue .due`, `.overdue-badge`)을 만족시킨다.
- **스키마 변경 없음** — `db-migrate.yml` 영향 없음.
- **`todayIso`는 Server Component에서** `getTodayIso()` (Asia/Seoul 자정 경계) 한 번 호출 → client prop으로 내려보내는 기존 패턴(`app/gantt/page.tsx`)을 `app/page.tsx`에도 동일 적용. SSR/CSR 시계 불일치 회피.
- **`is-done`과 `overdue` 클래스 공존 방지**: `isOverdue`는 `status === 'done'`일 때 false → 두 클래스가 동시에 붙지 않음. 단위 테스트(슬라이스 1)가 보장.
- 이슈 #7이 미리 박아둔 `--danger`/`--danger-bg`/`--danger-border` 토큰을 그대로 재사용 (`app/globals.css:32-34`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
