### PR TITLE
chore: #16 GitHub Actions SHA 핀 + Dependabot github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -67,9 +67,9 @@ jobs:
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
Closes #16

## Summary
- GitHub Actions third-party 액션의 부동 태그(`@v4`)를 **40자 commit SHA**로 핀해 서플라이체인 공격(태그 탈취·force-push)에 대비.
- `.github/dependabot.yml` 신규 추가 — 매주 `github-actions` 생태계 업데이트 PR을 자동 생성해 "고정"과 "최신성"을 동시에 확보.
- `permissions: contents: read`(PR #12에서 선반영)는 그대로 유지. 워크플로우 로직은 변경하지 않음.

## TDD 증적
- 인프라/순수 설정 변경이라 RED 테스트 슬라이스 없음 (`plan-issue` 스킬의 "UI 폴리시·순수 설정 예외" 적용). 검증은 CI green/red로 갈음.

## SHA 핀 결과

| Action | Commit SHA | Tag |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |

세 액션 모두 `git/ref/tags/v4`의 `object.type`이 `commit` — annotated tag dereference 불필요.

## Test plan
- [x] `npm run lint` 로컬 초록불 (no warnings/errors)
- [x] `npm test` 로컬 초록불 (68 passed)
- [x] `npm run build` 로컬 초록불
- [x] `git diff` 로 `permissions:` 블록·잡 구조 무변경 확인 (uses 7라인 + dependabot.yml 신규만)
- [x] CI `lint-unit-build` 초록불 — [run 25095079279](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25095079279/job/73529821387)
- [x] CI `e2e` 초록불 — [run 25095079279](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25095079279/job/73529821382)

## 파일 변경 요약

| # | 파일 | 구분 | 비고 |
|---|---|---|---|
| 1 | `.github/workflows/ci.yml` | 수정 | `uses:` 5라인 SHA 핀 (checkout × 2, setup-node × 2, upload-artifact × 1) |
| 2 | `.github/workflows/db-migrate.yml` | 수정 | `uses:` 2라인 SHA 핀 (checkout, setup-node) |
| 3 | `.github/dependabot.yml` | 신규 | `package-ecosystem: github-actions`, `interval: weekly`, PR limit 5 |

## 관련 시나리오 (USER_JOURNEY.md)

- **매핑 없음** — 인프라/보안 하드닝, 사용자 가시 변화 0건. J1~J17 회귀는 CI green으로 간접 확인.

## 주의

- SPEC.md §9 범위 밖 항목 미접촉.
- 향후 SHA 갱신은 사람이 손으로 다시 박지 않고 **Dependabot 주간 PR로** 자동화. 첫 주기는 머지 후 약 1주 내 관찰.
- annotated tag 함정 회피: 모든 액션이 `type: commit`이라 추가 dereference 불필요했음을 검증함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

