### PR TITLE
ci: #37 db-migrate.yml에 PRODUCTION_DATABASE_URL 5432 포트 사전 가드 추가

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -50,6 +50,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate DATABASE_URL port (must be 5432)
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::PRODUCTION_DATABASE_URL secret 이 비어 있습니다. production environment 설정을 확인하세요."
+            exit 1
+          fi
+          if echo "$DATABASE_URL" | grep -qE ':6543(/|$|\?)'; then
+            echo "::error::Transaction pooler(6543) URL 감지 — Direct/Session pooler(5432) URL 로 교체하세요. 마이그레이션은 5432 가 필수 (CLAUDE.md §6)."
+            exit 1
+          fi
+
       - name: Apply Drizzle migrations
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -54,14 +54,27 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
         run: |
-          if [ -z "$DATABASE_URL" ]; then
+          if [ -z "${DATABASE_URL:-}" ]; then
             echo "::error::PRODUCTION_DATABASE_URL secret 이 비어 있습니다. production environment 설정을 확인하세요."
             exit 1
           fi
-          if echo "$DATABASE_URL" | grep -qE ':6543(/|$|\?)'; then
-            echo "::error::Transaction pooler(6543) URL 감지 — Direct/Session pooler(5432) URL 로 교체하세요. 마이그레이션은 5432 가 필수 (CLAUDE.md §6)."
-            exit 1
-          fi
+          # postgresql://user:pw@host:PORT/db?... 에서 PORT만 추출 (평문 echo 없이 parameter expansion)
+          hostport="${DATABASE_URL#*://}"
+          hostport="${hostport#*@}"
+          hostport="${hostport%%/*}"
+          hostport="${hostport%%\?*}"
+          port="${hostport##*:}"
+          case "$port" in
+            5432) : ;;
+            6543)
+              echo "::error::Transaction pooler(6543) URL 감지 — Direct/Session pooler(5432) 로 교체하세요. 마이그레이션은 5432 가 필수 (CLAUDE.md §6)."
+              exit 1
+              ;;
+            *)
+              echo "::error::비표준 또는 누락된 포트($port) 감지 — Direct/Session pooler(5432) 만 허용 (CLAUDE.md §6)."
+              exit 1
+              ;;
+          esac
 
       - name: Apply Drizzle migrations
         env:


### PR DESCRIPTION
Closes #37

## Summary

- `.github/workflows/db-migrate.yml` 의 `Apply Drizzle migrations` 직전에 **`PRODUCTION_DATABASE_URL` 형식 검증 가드 스텝**을 추가.
- 빈 값이거나 5432 외 포트(특히 Transaction pooler `:6543`)가 감지되면 명시적 한국어 `::error::` 메시지로 fail-fast → drizzle-kit 의 `prepared statement "s1" already exists` 같은 드라이버 에러로 원인이 묻히는 문제를 사전 차단.
- 근거: PR #36 (`ci: #9 PRODUCTION_DATABASE_URL 가드 제거`) 머지 직후 multi-agent-review 의 security-reviewer + test-engineer 두 관점이 독립적으로 동시에 지목한 후속 가드 (출처: PR #36 review C1).
- CLAUDE.md §6 (마이그레이션은 5432 가 필수) · §10 (Transaction pooler 마이그레이션 금지) 에 정렬.

## 커밋 구성 (한 PR = 한 논리 단위 §9 준수)

1. **`ci: #37 db-migrate.yml에 PRODUCTION_DATABASE_URL 5432 포트 사전 가드 추가`** (`d1bfcb6`)
   - 초기 가드 — `grep -qE ':6543(/|$|\?)'` 블랙리스트 방식.
2. **`refactor: #37 가드를 5432 화이트리스트 + parameter expansion으로 강화`** (`2a01873`)
   - PR multi-agent-review C1 반영 — bash parameter expansion 으로 포트 추출 + `case` 분기로 5432 화이트리스트.
   - `echo "$DATABASE_URL"` 호출 자체를 제거 → `ACTIONS_STEP_DEBUG=true` / `set -x` 환경에서도 누설 표면 0.
   - `:5433`, `:6544`, `:65430` 같은 향후 비표준 포트 자동 fail-fast (defense-in-depth).
   - `${DATABASE_URL:-}` 사용 → 향후 `set -u` 도입 시 unbound 회귀 안전벨트.

## TDD 증적

이슈 본문에 명시된 **TDD 적용 예외** — workflow 자체는 자동 단위 테스트 대상이 아님. 검증은 다음으로 갈음:

- YAML 구문 정합성: `node -e "require('js-yaml').load(...)"` → `YAML OK` (두 커밋 모두).
- **로컬 17 케이스 회귀 검증** (parameter expansion 기반 포트 추출):

| 카테고리 | 케이스 | 결과 |
|---|---|---|
| 5432 정상 | `:5432/db`, `:5432`, `:5432/db?sslmode=req`, `db.proj.supabase.co:5432/postgres` | 4/4 PASS |
| 6543 차단 | `:6543/db`, `:6543`, `:6543/db?sslmode=req`, `:6543?ssl=require` | 4/4 BLOCK-6543 |
| 비표준 포트 차단 | `:5433`, `:6544`, `:65430`, `:65432` | 4/4 BLOCK-OTHER (whitelist 효과) |
| IPv6 | `[::1]:6543`, `[::1]:5432`, `[2001:db8::1]:6543` | 3/3 정확 |
| 비밀번호 `@` 포함 | `u:p@x@h:5432/db`, `u:p@x@h:6543/db` | 2/2 정확 |
| auth 누락 | `h:5432/db`, `h:6543/db` | 2/2 정확 |

(실측 결과 — false positive `:65430`/`:65432` 는 이전 정규식에서는 PASS 였으나 화이트리스트 전환 후 BLOCK-OTHER 로 전환됨. 이는 의도된 강화 — 두 포트는 합법 Postgres 포트가 아니므로 운영 사고를 막는 방향.)

- 정상 시나리오 (5432): 머지 후 `workflow_dispatch` 로 트리거하면 가드 통과 + drizzle-kit migrate 가 멱등 no-op 으로 ✅ — Phase 5 머지 후 검증 항목.
- 회귀 시나리오 (6543): secret 일시 변경으로 명시적 에러 메시지 노출 확인. **운영 secret 회전 부담이 있어 본 PR 에서는 스킵** — 위 17 케이스의 로컬 단위 행동으로 갈음.

## Test plan

- [x] `npm run lint` 로컬 초록불 (두 커밋 후 재검증)
- [x] `npm test` 로컬 초록불 (68 passed / 9 files)
- [x] `npm run build` 로컬 초록불
- [x] YAML 구문 파싱 OK (두 커밋)
- [x] 가드 로직 17/17 케이스 회귀 검증 — 5432 정상 / 6543 차단 / 비표준 포트 차단 / IPv6 / 비밀번호 @ / auth 누락 모두 정확
- [x] CI `lint + vitest + build` 초록불 (1차) — 1m17s ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25297037723/job/74157474360))
- [x] CI `playwright e2e (chromium)` 초록불 (1차) — 2m39s ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25297037723/job/74157474375))
- [x] CI `lint + vitest + build` 초록불 (refactor 후 재실행) — 1m29s ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25297289962/job/74158142773))
- [x] CI `playwright e2e (chromium)` 초록불 (refactor 후 재실행) — 2m53s ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25297289962/job/74158142783))
- [ ] (머지 후) `workflow_dispatch` 수동 트리거 → 가드 통과 + drizzle-kit migrate 멱등 no-op ✅

## 파일 변경 요약

| # | 파일 | 구분 | 변경량 | 비고 |
|---|---|---|---|---|
| 1 | `.github/workflows/db-migrate.yml` | 수정 | +26 / -0 | `Apply Drizzle migrations` 직전에 검증 스텝 1개 (parameter expansion + case whitelist) |

## 관련 시나리오 (USER_JOURNEY.md)

매핑 없음 — CI 운영 가드라 사용자 여정과 무관. SPEC.md / USER_JOURNEY.md 갱신 불필요 (CLAUDE.md §1-B 의 "기능 구현·변경 요청" 범주 밖).

## 후속 별도 이슈 (multi-agent-review P1/P2)

본 PR 머지 후 별도 이슈로 분리 예정:
- **P1**: `actionlint` 를 `ci.yml` 에 도입 — workflow 편집의 `${{ secrets.TYPO }}` 같은 정적 오류 정적 탐지 (test-engineer Major).
- **P2**: `CODEOWNERS` + branch protection 으로 `.github/workflows/**` 수정 시 리뷰 강제 — supply-chain 방어 (security-reviewer L2).

## 주의

- **Secret 평문 노출 금지**: `env:` 주입만 사용 + `echo $DATABASE_URL` 호출 자체를 제거 (refactor 커밋). port 변수만 `case` 분기에 사용하므로 디버그 모드에서도 secret 누설 표면 0.
- **PR #36 의 변경을 무효화하지 않음**: #36 은 "마이그레이션 실 적용" 으로 가드를 풀었고, 본 PR 은 "마이그레이션 자체는 그대로 돌되, 그 직전에 형식만 검증" → fail 시 마이그레이션이 실 적용되기 전에 멈추므로 안전 방향.
- **SPEC.md §9 범위 밖 항목 미접촉**: 다중 사용자 / Task 의존성 / 크리티컬 패스 / 간트 드래그 편집 등 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
