### PR TITLE
ci: #45 actionlint 도입 — workflow 정적 검증

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,19 @@ jobs:
       - name: Install actionlint
         env:
           ACTIONLINT_VERSION: "1.7.5"
+          # rhysd/actionlint v1.7.5 actionlint_1.7.5_linux_amd64.tar.gz SHA-256.
+          # 갱신 시 사람이 `gh release download <ver> -R rhysd/actionlint -p actionlint_<ver>_checksums.txt`
+          # 로 직접 검증 후 박는다 (in-patch SHA → git blame 에 검증 증적).
+          ACTIONLINT_SHA256: "3e6e0a832dfa0b5f027e6b8956aad2632d69b7cb778b1cff847b40279950a856"
         run: |
-          curl -sSL \
-            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-            | tar -xz -C /tmp actionlint
-          /tmp/actionlint -version
+          set -euo pipefail
+          cd /tmp
+          curl -fsSL --retry 3 --retry-delay 2 -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+          rm actionlint.tar.gz
+          ./actionlint -version
 
       - name: Lint GitHub Actions workflows
         run: /tmp/actionlint -color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
         run: npm run lint
 
       - name: Unit / contract tests
+        env:
+          # tests/contract/actionlint-binary.test.ts 가 회귀 가드로 사용
+          ACTIONLINT_BIN: /tmp/actionlint
         run: npm test
 
       - name: Next.js build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.5"
+        run: |
+          curl -sSL \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /tmp actionlint
+          /tmp/actionlint -version
+
+      - name: Lint GitHub Actions workflows
+        run: /tmp/actionlint -color
+
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"

--- a/tests/contract/actionlint-binary.test.ts
+++ b/tests/contract/actionlint-binary.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const BINARY = process.env.ACTIONLINT_BIN ?? 'actionlint';
+const FIXTURE = resolve(__dirname, '../fixtures/broken-workflow.yml');
+
+const isAvailable = (() => {
+  try {
+    execFileSync(BINARY, ['-version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe.skipIf(!isAvailable)('actionlint contract (Issue #45)', () => {
+  it('exposes a parseable version (vX.Y.Z)', () => {
+    const out = execFileSync(BINARY, ['-version'], { encoding: 'utf8' });
+    expect(out).toMatch(/\d+\.\d+\.\d+/);
+  });
+
+  it('returns nonzero exit code for a known-broken workflow fixture', () => {
+    let threw = false;
+    try {
+      execFileSync(BINARY, [FIXTURE], { encoding: 'utf8', stdio: 'pipe' });
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+  });
+});

--- a/tests/fixtures/broken-workflow.yml
+++ b/tests/fixtures/broken-workflow.yml
@@ -1,0 +1,10 @@
+# 의도적으로 깨진 워크플로우. tests/contract/actionlint-binary.test.ts 의 fixture.
+# 절대 수정 금지 — actionlint 가 실제로 오류를 잡는다는 것을 회귀 가드로 단언하기 위한 파일.
+# `${{ typo.invalid_context }}` 가 actionlint 의 알려지지 않은 context 룰에 잡혀야 함.
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo ${{ typo.invalid_context }}


### PR DESCRIPTION
Closes #45

## Summary

- `.github/workflows/ci.yml` 의 `lint-unit-build` 잡 **`actions/checkout` 직후** 에 [`actionlint`](https://github.com/rhysd/actionlint) 다운로드 + 실행 스텝 2개를 추가.
- `npm ci` (40+초) **이전** 단계라 워크플로우 오류 시 fail-fast — 미래 워크플로우 PR 의 디버깅 비용 절감.
- 자동 발견된 `.github/workflows/*.yml` 전수 (현재 `ci.yml` + `db-migrate.yml`) 를 정적 검증 — `${{ secrets.TYPO }}` / 존재하지 않는 action 태그 / expression syntax 오류 / `run: |` bash 경고 (shellcheck 자동 동반) 모두 잡음.
- 근거: PR #44 (`refactor: #37`) multi-agent-review 의 test-engineer **Major** ("`actionlint` 부재"). 의존 순서상 본 PR (#45) → CODEOWNERS PR (#46) — 후자 자체가 워크플로우 변경이라 본 lint 가 먼저 깔려야 같은 게이트 통과.

## TDD 적용 예외

이슈 본문 + 이슈 #37 와 동일 — workflow 자체는 자동 단위 테스트 대상 아님. 검증은 다음으로 갈음:

**사전 검증 (구현 시작 전)** — 로컬에서 actionlint v1.7.5 다운로드 후 `main` 브랜치 워크플로우 둘 다 실행:
```
$ /tmp/actionlint -color
(빈 출력 — clean)
```
→ 기존 워크플로우 오류 없음 → 선행 fix 슬라이스 불필요.

**self-lint** — 본 PR 의 ci.yml 변경 후 같은 명령 재실행:
```
$ /tmp/actionlint -color
(빈 출력 — clean)
```
→ 추가한 2개 스텝 자체도 actionlint 통과.

**(선택) 회귀 라이브 테스트** — 의도적 typo 추가 → CI 의 `Lint GitHub Actions workflows` 스텝이 fail 하는지 확인 → 제거. **본 PR 머지 전 별도 검증 푸시로 수행하지 않음** (CI 비용 + secret 회전 부담 없음 — 단순 typo 회귀라 사후 검증 가치 낮음).

## Test plan

- [x] `npm run lint` 로컬 초록불
- [x] `npm test` 로컬 초록불 (68 passed / 9 files)
- [x] `npm run build` 로컬 초록불
- [x] 사전 검증 — `actionlint v1.7.5` 가 `main` 브랜치 워크플로우 둘 다 clean 통과
- [x] self-lint — 본 PR 의 `ci.yml` 변경 후 actionlint clean 통과
- [x] YAML 파싱 OK
- [x] CI `lint + vitest + build` 초록불 (1차) — 1m15s ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25297659449/job/74159082183)) — 새 `Install actionlint` + `Lint GitHub Actions workflows` 스텝 포함, 모두 success
- [x] CI `playwright e2e (chromium)` 초록불 (1차) — 2m31s ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25297659449/job/74159082184))
- [x] CI `lint + vitest + build` 초록불 (review fix 반영 후 재실행) — 1m17s ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25301565758/job/74169299685)) — `Install actionlint` 가 SHA-256 검증 + sha256sum -c 통과 ✅, vitest 10 files / 70 tests (신규 contract 2건 skip 없이 실행)
- [x] CI `playwright e2e (chromium)` 초록불 (재실행) — 2m44s ([run](https://github.com/junyoungDihisoft/claude-vercel-wbs/actions/runs/25301565758/job/74169299677))

## 추가 커밋 (multi-agent-review C1 + 보안 H1 + 테스트 Major 반영)

- `fix: #45 actionlint tarball SHA-256 검증 + curl 강화` (`cf0cd45`) — in-patch SHA-256(`3e6e0a83...0a856`) + `set -euo pipefail` + `curl -fsSL --retry 3` + 디스크 다운로드 후 sha256sum 검증.
- `test: #45 actionlint contract — 의도적 typo 잡는지 단언` (`8c882b6`) — `tests/contract/actionlint-binary.test.ts` + `tests/fixtures/broken-workflow.yml` + `ci.yml`에 `ACTIONLINT_BIN=/tmp/actionlint` env 주입. 로컬에선 binary 없으면 graceful skip.

## 파일 변경 요약

| # | 파일 | 구분 | 변경량 | 비고 |
|---|---|---|---|---|
| 1 | `.github/workflows/ci.yml` | 수정 | +12 / -0 | `lint-unit-build` 잡의 `actions/checkout` 직후 `Install actionlint` + `Lint GitHub Actions workflows` 스텝 2개 추가. `setup-node` 이전 위치라 npm ci 비용 전 fail-fast |

## 관련 시나리오 (USER_JOURNEY.md)

매핑 없음 — CI 인프라 가드라 사용자 여정과 무관. SPEC.md / USER_JOURNEY.md 갱신 불필요 (CLAUDE.md §1-B 의 "기능 구현·변경 요청" 범주 밖).

## 후속 이슈

- **#46** ([security] CODEOWNERS + branch protection) — 본 PR 머지 후 자연 진행. #46 PR 자체가 워크플로우 변경 (`.github/CODEOWNERS` 추가) 이라 본 lint 통과 게이트 활용.

## 주의

- **버전 핀 (`1.7.5`) 관리**: Dependabot 의 github-actions ecosystem 은 `uses:` 형태만 추적 — raw binary 다운로드는 자동 추적 X. 향후 actionlint 갱신은 사람이 release notes 보고 명시적으로 한다 (1년 1~2회 수동).
- **3rd-party action 미사용**: 이슈 #16 SHA 핀 컨벤션 정합. raw binary + 버전 핀 + `/tmp/actionlint -version` 으로 다운로드 무결성 1차 확인.
- **shellcheck 자동 동반**: actionlint 가 `run: |` 블록 발견 시 자체적으로 shellcheck 호출. 미래 PR 에서 SC2086 (unquoted variables) 같은 bash 경고가 같이 잡힐 수 있음 — 의도적 무시는 `-ignore` 옵션으로 명시적 화이트리스트 (사일런트 무시 금지).
- **CLAUDE.md §10 금기 미접촉**: workflow 변경뿐, 스키마·UI·secret 취급 무관.
- **변경 면적 작음**: `.github/workflows/ci.yml` 1파일 +12줄 — CLAUDE.md §9 "한 커밋 = 한 논리 단위" 충족.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
